### PR TITLE
Use ArrayBase instead of Array

### DIFF
--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -1,4 +1,4 @@
-use ndarray::{arr1, s, Array, Array1, ArrayViewMut1, Axis, Dimension};
+use ndarray::{arr1, s, Array, Array1, ArrayBase, ArrayViewMut1, Axis, Data, Dimension};
 use num_traits::{AsPrimitive, Float, FromPrimitive};
 
 /// Multidimensional spline filter.
@@ -9,14 +9,15 @@ use num_traits::{AsPrimitive, Float, FromPrimitive};
 /// * `order` - The order of the spline.
 ///
 /// **Panics** if `order` isn't in the range \[2, 5\].
-pub fn spline_filter<A, D>(data: &Array<A, D>, order: usize) -> Array<A, D>
+pub fn spline_filter<S, A, D>(data: &ArrayBase<S, D>, order: usize) -> Array<A, D>
 where
+    S: Data<Elem = A>,
     A: Clone + Copy + Float + FromPrimitive + 'static,
     f64: AsPrimitive<A>,
     D: Dimension,
 {
     if data.len() == 1 {
-        return data.clone();
+        return data.to_owned();
     }
 
     let poles = get_filter_poles(order);
@@ -38,14 +39,15 @@ where
 /// * `axis` - The axis along which the spline filter is applied.
 ///
 /// **Panics** if `order` isn't in the range \[0, 5\].
-pub fn spline_filter1d<A, D>(data: &Array<A, D>, order: usize, axis: Axis) -> Array<A, D>
+pub fn spline_filter1d<S, A, D>(data: &ArrayBase<S, D>, order: usize, axis: Axis) -> Array<A, D>
 where
+    S: Data<Elem = A>,
     A: Clone + Copy + Float + FromPrimitive + 'static,
     f64: AsPrimitive<A>,
     D: Dimension,
 {
     if order == 0 || order == 1 || data.len() == 1 {
-        return data.clone();
+        return data.to_owned();
     }
 
     let poles = get_filter_poles(order);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! The `ndarray-image` crate provides multidimensional image processing for `ArrayBase`,
 //! the *n*-dimensional array data structure provided by [`ndarray`].
 
-use ndarray::{Array3, ArrayBase, DataOwned, Dimension, ShapeBuilder};
+use ndarray::{Array, Array3, ArrayBase, Data, Dimension, Ix3, ShapeBuilder};
 
 mod filters;
 mod interpolation;
@@ -31,23 +31,27 @@ pub enum Kernel3d {
 
 /// Utilitary function that returns a new *n*-dimensional of dimension `shape` with the same
 /// datatype and memory order as the input `arr`.
-pub fn array_like<S, A, D, Sh>(arr: &ArrayBase<S, D>, shape: Sh, elem: A) -> ArrayBase<S, D>
+pub fn array_like<S, A, D, Sh>(arr: &ArrayBase<S, D>, shape: Sh, elem: A) -> Array<A, D>
 where
-    S: DataOwned<Elem = A>,
+    S: Data<Elem = A>,
     A: Clone,
     D: Dimension,
     Sh: ShapeBuilder<Dim = D>,
 {
     // TODO `is_standard_layout` only works on owned arrays. Change it if using `ArrayBase`.
     if arr.is_standard_layout() {
-        ArrayBase::from_elem(shape, elem)
+        Array::from_elem(shape, elem)
     } else {
-        ArrayBase::from_elem(shape.f(), elem)
+        Array::from_elem(shape.f(), elem)
     }
 }
 
 /// Utilitary function that returns the mask dimension minus 1 on all dimensions.
-pub fn dim_minus_1(mask: &Mask) -> (usize, usize, usize) {
+pub fn dim_minus_1<S, A>(mask: &ArrayBase<S, Ix3>) -> (usize, usize, usize)
+where
+    S: Data<Elem = A>,
+    A: Clone,
+{
     let (width, height, depth) = mask.dim();
     (width - 1, height - 1, depth - 1)
 }

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -1,4 +1,4 @@
-use ndarray::{s, Zip};
+use ndarray::{s, ArrayBase, Data, Ix3, Zip};
 
 use crate::{array_like, dim_minus_1, Kernel3d, Mask};
 
@@ -6,9 +6,12 @@ use crate::{array_like, dim_minus_1, Kernel3d, Mask};
 ///
 /// * `mask` - Binary image to be eroded.
 /// * `kernel` - Structuring element used for the erosion.
-pub fn binary_erosion(mask: &Mask, kernel: Kernel3d) -> Mask {
+pub fn binary_erosion<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d) -> Mask
+where
+    S: Data<Elem = bool>,
+{
     // By definition, all borders are set to 0
-    let mut eroded_mask = mask.clone();
+    let mut eroded_mask = mask.to_owned();
     let (width, height, depth) = dim_minus_1(mask);
     eroded_mask.slice_mut(s![0, .., ..]).fill(false);
     eroded_mask.slice_mut(s![width, .., ..]).fill(false);
@@ -44,7 +47,10 @@ pub fn binary_erosion(mask: &Mask, kernel: Kernel3d) -> Mask {
 ///
 /// * `mask` - Binary image to be dilated.
 /// * `kernel` - Structuring element used for the dilation.
-pub fn binary_dilation(mask: &Mask, kernel: Kernel3d) -> Mask {
+pub fn binary_dilation<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d) -> Mask
+where
+    S: Data<Elem = bool>,
+{
     let (width, height, depth) = mask.dim();
     let crop = s![1..=width, 1..=height, 1..=depth];
     let mut new_mask = array_like(mask, (width + 2, height + 2, depth + 2), false);

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -1,6 +1,6 @@
 //! This modules defines some image padding methods for 3D images.
 
-use ndarray::{Array3, ArrayView3, ShapeBuilder};
+use ndarray::{Array3, ArrayBase, Data, Ix3, ShapeBuilder};
 use num_traits::Zero;
 
 type PadSize = (usize, usize, usize);
@@ -25,9 +25,10 @@ pub enum PadMode {
 /// * `pad_width` - Number of values padded to the edges of each axis.
 /// * `mode` - Method that will be used to select the padded values. See the
 ///   [`PadMode`](crate::PadMode) enum for more information.
-pub fn pad<T>(data: ArrayView3<T>, pad_width: PadSize, mode: PadMode) -> Array3<T>
+pub fn pad<S, A>(data: &ArrayBase<S, Ix3>, pad_width: PadSize, mode: PadMode) -> Array3<A>
 where
-    T: Zero + Clone + Copy,
+    S: Data<Elem = A>,
+    A: Zero + Clone + Copy,
 {
     let indices = |size: usize, padding: usize| match mode {
         PadMode::Reflect => reflect_indices(size, padding),
@@ -75,15 +76,16 @@ fn wrap_indices(size: usize, padding: usize) -> Vec<u16> {
     v
 }
 
-fn pad_by_indices<T>(
-    data: ArrayView3<T>,
+fn pad_by_indices<S, A>(
+    data: &ArrayBase<S, Ix3>,
     pad: PadSize,
     indices_i: Vec<u16>,
     indices_j: Vec<u16>,
     indices_k: Vec<u16>,
-) -> Array3<T>
+) -> Array3<A>
 where
-    T: Zero + Clone + Copy,
+    S: Data<Elem = A>,
+    A: Zero + Clone + Copy,
 {
     let width = data.dim().0 + 2 * pad.0;
     let height = data.dim().1 + 2 * pad.1;

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -29,7 +29,7 @@ fn test_median_filter() {
 
     gt[(2, 0, 0)] = true;
     mask[(1, 1, 1)] = true;
-    assert_eq!(median_filter(&mask), gt);
+    assert_eq!(median_filter(&mask.view()), gt);
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_gaussian_filter_1d() {
     );
     a[0] = 0.7;
     assert_relative_eq!(
-        gaussian_filter(&a, 2.0, 3.0),
+        gaussian_filter(&a.view(), 2.0, 3.0),
         arr1(&[1.4193099, 1.737984, 2.3200142, 3.0642939, 3.8351974, 4.4778357, 4.845365]),
         epsilon = 1e-5
     );

--- a/tests/interpolation.rs
+++ b/tests/interpolation.rs
@@ -51,7 +51,7 @@ fn test_spline_filter_1d() {
 
     let data = arr1(&[0.3, 0.2, 0.5, -0.1, 0.4]);
     assert_relative_eq!(
-        spline_filter(&data, 3),
+        spline_filter(&data.view(), 3),
         arr1(&[0.47321429, -0.04642857, 0.9125, -0.60357143, 0.90178571]),
         epsilon = 1e-5
     );
@@ -161,7 +161,7 @@ fn test_spline_filter_3d() {
 fn test_spline_filter1d() {
     let data = arr2(&[[0.5, 0.4], [0.3, 0.4]]);
     assert_relative_eq!(
-        spline_filter1d(&data, 2, Axis(0)),
+        spline_filter1d(&data.view(), 2, Axis(0)),
         arr2(&[[0.6, 0.4], [0.2, 0.4]]),
         epsilon = 1e-5
     );

--- a/tests/measurements.rs
+++ b/tests/measurements.rs
@@ -172,7 +172,7 @@ fn test_label_5() {
             [3, 0, 0, 0, 0],
         ],
     ]);
-    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7));
+    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7).view());
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 3);
     assert_eq!(label_histogram(&gt, nb_features), vec![113, 33, 2, 2]);
@@ -197,5 +197,5 @@ fn test_largest_connected_components() {
     gt.slice_mut(s![2..4, 2..4, 2..4]).fill(true);
     gt[(3, 3, 4)] = true;
     gt[(3, 4, 4)] = true;
-    assert_eq!(largest_connected_components(&mask).unwrap(), gt);
+    assert_eq!(largest_connected_components(&mask.view()).unwrap(), gt);
 }

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -12,7 +12,7 @@ fn test_binary_erosion() {
 
     mask[(0, 2, 2)] = false;
     gt[(1, 2, 2)] = false;
-    assert_eq!(binary_erosion(&mask, Kernel3d::Star), gt);
+    assert_eq!(binary_erosion(&mask.view(), Kernel3d::Star), gt);
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
@@ -77,7 +77,7 @@ fn test_binary_dilation_plain() {
     gt.slice_mut(s![2..w - 1, 2..h - 1, 1..d]).fill(true);
     gt.slice_mut(s![2..w - 1, h - 1, 2..d - 1]).fill(true);
 
-    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Star));
+    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Star));
 }
 
 #[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)

--- a/tests/pad.rs
+++ b/tests/pad.rs
@@ -11,7 +11,7 @@ fn simple_data() -> Array3<f64> {
 fn test_pad_symmetric() {
     let data = simple_data();
     assert_relative_eq!(
-        pad(data.view(), (1, 1, 1), PadMode::Symmetric),
+        pad(&data, (1, 1, 1), PadMode::Symmetric),
         arr3(&[
             [
                 [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
@@ -44,7 +44,7 @@ fn test_pad_symmetric() {
         ])
     );
     assert_relative_eq!(
-        pad(data.view(), (0, 1, 2), PadMode::Symmetric),
+        pad(&data, (0, 1, 2), PadMode::Symmetric),
         arr3(&[
             [
                 [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
@@ -68,7 +68,7 @@ fn test_pad_symmetric() {
 fn test_pad_wrap() {
     let data = simple_data();
     assert_relative_eq!(
-        pad(data.view(), (1, 1, 1), PadMode::Wrap),
+        pad(&data, (1, 1, 1), PadMode::Wrap),
         arr3(&[
             [
                 [23.0, 20.0, 21.0, 22.0, 23.0, 20.0],
@@ -101,7 +101,7 @@ fn test_pad_wrap() {
         ])
     );
     assert_relative_eq!(
-        pad(data.view(), (0, 1, 2), PadMode::Wrap),
+        pad(&data, (0, 1, 2), PadMode::Wrap),
         arr3(&[
             [
                 [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0, 9.0],
@@ -125,7 +125,7 @@ fn test_pad_wrap() {
 fn test_pad_reflect() {
     let data = simple_data();
     assert_relative_eq!(
-        pad(data.view(), (1, 1, 1), PadMode::Reflect),
+        pad(&data, (1, 1, 1), PadMode::Reflect),
         arr3(&[
             [
                 [17.0, 16.0, 17.0, 18.0, 19.0, 18.0],
@@ -158,7 +158,7 @@ fn test_pad_reflect() {
         ])
     );
     assert_relative_eq!(
-        pad(data.view(), (0, 1, 2), PadMode::Reflect),
+        pad(&data.view(), (0, 1, 2), PadMode::Reflect),
         arr3(&[
             [
                 [6.0, 5.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0],


### PR DESCRIPTION
We could only use owned arrays. Using `ArrayBase` fixes this.

Fixes #1 