### PR TITLE
Correlate and Convolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It aims to:
 - avoid using `unsafe`. This is not an unbreakable rule. Its usage will be evaluated and dicussed in the pull requests.
 
 Currently available routines include:
-- Filters: gaussian_filter, gaussian_filter1d, median_filter
+- Filters: correlate, correlate1d, gaussian_filter, gaussian_filter1d, median_filter
 - Fourier filters: none. Please use the excellent [`rustfft`] crate
 - Interpolation: spline_filter, spline_filter1d
 - Measurements: label, label_histogram, largest_connected_components, most_frequent_label

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -78,9 +78,12 @@ where
     }
 
     let weights = Zip::from(weights.slice(s![..; -1])).map_collect(|&w| w);
+
+    origin = -origin;
     if weights.len() % 2 == 0 {
         origin -= 1;
     }
+
     _correlate1d(data, weights.as_slice().unwrap(), axis, mode, origin)
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -73,7 +73,7 @@ pub fn correlate1d<S, A, D>(
 where
     S: Data<Elem = A>,
     // TODO Should be Num, not Float
-    A: Float + ScalarOperand + FromPrimitive,
+    A: Float + ScalarOperand + FromPrimitive + std::fmt::Debug,
     D: Dimension,
 {
     if weights.len() == 1 {
@@ -88,7 +88,7 @@ where
 
     let mode = mode.to_pad_mode();
     let n = data.len_of(axis);
-    let mut buffer = Array1::zeros(n + 2 * size1);
+    let mut buffer = Array1::from_elem(n + 2 * size1, mode.init());
 
     let mut output = data.to_owned();
     Zip::from(data.lanes(axis)).and(output.lanes_mut(axis)).for_each(|input, o| {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -44,19 +44,6 @@ impl<T: Copy> CorrelateMode<T> {
     }
 }
 
-/*pub fn correlate<S, A, D>(
-    data: &ArrayBase<S, D>,
-    weights: &ArrayBase<S, D>,
-    axis: Axis,
-) -> Array<A, D>
-where
-    S: Data<Elem = A>,
-    A: Float + ToPrimitive,
-    D: Dimension,
-{
-    //
-}*/
-
 /// Calculate a 1-D correlation along the given axis.
 ///
 /// The lines of the array along the given axis are correlated with the given weights.
@@ -73,7 +60,7 @@ pub fn correlate1d<S, A, D>(
 where
     S: Data<Elem = A>,
     // TODO Should be Num, not Float
-    A: Float + ScalarOperand + FromPrimitive + std::fmt::Debug,
+    A: Float + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
     if weights.len() == 1 {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -68,6 +68,9 @@ where
     A: Float + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
+    if weights.is_empty() {
+        panic!("No filter weights given");
+    }
     if weights.len() == 1 {
         return data.to_owned() * weights[0];
     }
@@ -104,6 +107,9 @@ where
     A: Float + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
+    if weights.is_empty() {
+        panic!("No filter weights given");
+    }
     if weights.len() == 1 {
         return data.to_owned() * weights[0];
     }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -114,16 +114,13 @@ where
         return data.to_owned() * weights[0];
     }
 
-    #[allow(unused_assignments)]
-    let mut new_weights = Array1::zeros(0);
-    let weights = match weights.as_slice_memory_order() {
-        Some(s) => s,
+    match weights.as_slice_memory_order() {
+        Some(s) => _correlate1d(data, s, axis, mode, origin),
         None => {
-            new_weights = weights.to_owned();
-            new_weights.as_slice_memory_order().unwrap()
+            let weights = weights.to_owned();
+            _correlate1d(data, weights.as_slice_memory_order().unwrap(), axis, mode, origin)
         }
-    };
-    _correlate1d(data, weights, axis, mode, origin)
+    }
 }
 
 fn _correlate1d<S, A, D>(

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -110,13 +110,12 @@ where
 
     let mode = mode.to_pad_mode();
     let n = data.len_of(axis);
-    let left_pad = (size1 as isize + origin) as usize;
-    let right_pad = (size2 as isize - origin) as usize;
-    let mut buffer = Array1::from_elem(n + left_pad + right_pad, mode.init());
+    let pad = vec![[(size1 as isize + origin) as usize, (size2 as isize - origin) as usize]];
+    let mut buffer = Array1::from_elem(n + pad[0][0] + pad[0][1], mode.init());
 
     let mut output = data.to_owned();
     Zip::from(data.lanes(axis)).and(output.lanes_mut(axis)).for_each(|input, o| {
-        pad_to(&input, (left_pad, right_pad), mode, &mut buffer);
+        pad_to(&input, &pad, mode, &mut buffer);
         let buffer = buffer.as_slice_memory_order().unwrap();
 
         match symmetry_state {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod measurements;
 mod morphology;
 mod pad;
 
-pub use filters::{gaussian_filter, gaussian_filter1d, median_filter};
+pub use filters::{correlate1d, gaussian_filter, gaussian_filter1d, median_filter};
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};
 pub use morphology::{binary_dilation, binary_erosion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ mod morphology;
 mod pad;
 
 pub use filters::{
-    convolve1d, correlate1d, gaussian_filter, gaussian_filter1d, median_filter, CorrelateMode,
+    convolve1d, correlate, correlate1d, gaussian_filter, gaussian_filter1d, median_filter,
+    CorrelateMode,
 };
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ mod measurements;
 mod morphology;
 mod pad;
 
-pub use filters::{correlate1d, gaussian_filter, gaussian_filter1d, median_filter, CorrelateMode};
+pub use filters::{
+    convolve1d, correlate1d, gaussian_filter, gaussian_filter1d, median_filter, CorrelateMode,
+};
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};
 pub use morphology::{binary_dilation, binary_erosion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ mod morphology;
 mod pad;
 
 pub use filters::{
-    convolve1d, correlate, correlate1d, gaussian_filter, gaussian_filter1d, median_filter,
-    CorrelateMode,
+    convolve, convolve1d, correlate, correlate1d, gaussian_filter, gaussian_filter1d,
+    median_filter, CorrelateMode,
 };
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,11 @@ mod measurements;
 mod morphology;
 mod pad;
 
-pub use filters::{correlate1d, gaussian_filter, gaussian_filter1d, median_filter};
+pub use filters::{correlate1d, gaussian_filter, gaussian_filter1d, median_filter, CorrelateMode};
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};
 pub use morphology::{binary_dilation, binary_erosion};
-pub use pad::{pad, PadMode};
+pub use pad::{pad, pad_to, PadMode};
 
 /// 3D mask
 pub type Mask = Array3<bool>;

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -61,7 +61,7 @@ pub enum PadMode<T> {
 }
 
 impl<T: PartialEq> PadMode<T> {
-    fn init(&self) -> T
+    pub(crate) fn init(&self) -> T
     where
         T: Copy + Zero,
     {

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -150,12 +150,7 @@ where
     A: Copy + FromPrimitive + Num + PartialOrd,
     D: Dimension,
 {
-    let mut pad = Cow::from(pad);
-    if pad.len() == 1 && pad.len() < data.ndim() {
-        // The user provided a single padding for all dimensions
-        *pad.to_mut() = vec![pad[0]; data.ndim()];
-    }
-
+    let pad = read_pad(data.ndim(), pad);
     let mut new_dim = data.raw_dim();
     for (ax, (&ax_len, pad)) in data.shape().iter().zip(pad.iter()).enumerate() {
         new_dim[ax] = ax_len + pad[0] + pad[1];
@@ -185,11 +180,7 @@ pub fn pad_to<S, A, D>(
     A: Copy + FromPrimitive + Num + PartialOrd,
     D: Dimension,
 {
-    let mut pad = Cow::from(pad);
-    if pad.len() == 1 && pad.len() < data.ndim() {
-        // The user provided a single padding for all dimensions
-        *pad.to_mut() = vec![pad[0]; data.ndim()];
-    }
+    let pad = read_pad(data.ndim(), pad);
 
     // Select portion of padded array that needs to be copied from the original array.
     output
@@ -246,5 +237,16 @@ pub fn pad_to<S, A, D>(
                 });
             }
         }
+    }
+}
+
+fn read_pad(nb_dim: usize, pad: &[[usize; 2]]) -> Cow<[[usize; 2]]> {
+    if pad.len() == 1 && pad.len() < nb_dim {
+        // The user provided a single padding for all dimensions
+        Cow::from(vec![pad[0]; nb_dim])
+    } else if pad.len() == nb_dim {
+        Cow::from(pad)
+    } else {
+        panic!("Inconsistant number of dimensions and pad arrays");
     }
 }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -88,11 +88,13 @@ impl<T: PartialEq> PadMode<T> {
         T: Clone + Copy + FromPrimitive + Num + PartialOrd,
     {
         match *self {
-            PadMode::Minimum => *lane.min().unwrap(),
-            PadMode::Mean => lane.mean().unwrap(),
+            PadMode::Minimum => *lane.min().expect("Can't find min because of NaN values"),
+            PadMode::Mean => lane.mean().expect("Can't find mean because of NaN values"),
             PadMode::Median => {
                 buffer.assign(&lane);
-                buffer.as_slice_mut().unwrap().sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+                buffer.as_slice_mut().unwrap().sort_unstable_by(|a, b| {
+                    a.partial_cmp(b).expect("Can't find median because of NaN values")
+                });
                 let n = buffer.len();
                 let h = (n - 1) / 2;
                 let dadc = if n & 1 > 0 {
@@ -102,7 +104,7 @@ impl<T: PartialEq> PadMode<T> {
                 };
                 dadc
             }
-            PadMode::Maximum => *lane.max().unwrap(),
+            PadMode::Maximum => *lane.max().expect("Can't find max because of NaN values"),
             _ => panic!("Only Minimum, Median and Maximum have a dynamic value"),
         }
     }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -148,10 +148,21 @@ where
     A: Copy + FromPrimitive + Num + PartialOrd,
     D: Dimension,
 {
+    #[allow(unused_assignments)]
+    let mut full_pad = vec![];
+    let pad = if pad.len() == 1 && pad.len() < data.ndim() {
+        // The user provided a single padding for all dimensions
+        full_pad = vec![pad[0]; data.ndim()];
+        full_pad.as_slice()
+    } else {
+        pad
+    };
+
     let mut new_dim = data.raw_dim();
     for (ax, (&ax_len, &[pad_left, pad_right])) in data.shape().iter().zip(pad).enumerate() {
         new_dim[ax] = ax_len + pad_left + pad_right;
     }
+
     let mut padded = array_like(&data, new_dim, mode.init());
     pad_to(data, pad, mode, &mut padded);
     padded

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -2,7 +2,8 @@ use approx::assert_relative_eq;
 use ndarray::{arr1, arr2, s, Array1, Axis};
 
 use ndarray_ndimage::{
-    convolve1d, correlate, correlate1d, gaussian_filter, median_filter, CorrelateMode, Mask,
+    convolve, convolve1d, correlate, correlate1d, gaussian_filter, median_filter, CorrelateMode,
+    Mask,
 };
 
 #[test] // Results verified with SciPy. (v1.9.0)
@@ -279,6 +280,44 @@ fn test_correlate1d() {
     assert_eq!(
         correlate1d(&arr, &arr1(&[1.0, 0.5, 1.0, 1.5]), Axis(0), CorrelateMode::Reflect, 1),
         arr1(&[9.0, 23.0, 11.0, 12.0, 13.5, 16.5, 27.0, 14.5])
+    );
+}
+
+#[test] // Results verified with SciPy. (v1.9.0)
+fn test_convolve() {
+    let a: Array1<usize> = (0..25).collect();
+    let a = a.into_shape((5, 5)).unwrap();
+
+    let weight = arr2(&[[1, 0, 0], [0, 1, 0], [0, 0, 1]]);
+    assert_eq!(
+        convolve(&a, &weight, CorrelateMode::Mirror, 1),
+        arr2(&[
+            [18, 21, 24, 25, 24],
+            [33, 36, 39, 40, 39],
+            [48, 51, 54, 55, 54],
+            [53, 56, 59, 60, 59],
+            [48, 51, 54, 55, 54],
+        ])
+    );
+    assert_eq!(
+        convolve(&a, &weight, CorrelateMode::Reflect, 0),
+        arr2(&[
+            [6, 8, 11, 14, 16],
+            [16, 18, 21, 24, 26],
+            [31, 33, 36, 39, 41],
+            [46, 48, 51, 54, 56],
+            [56, 58, 61, 64, 66],
+        ])
+    );
+    assert_eq!(
+        convolve(&a, &weight, CorrelateMode::Wrap, -1),
+        arr2(&[
+            [42, 40, 38, 41, 44],
+            [32, 30, 28, 31, 34],
+            [22, 20, 18, 21, 24],
+            [37, 35, 33, 36, 39],
+            [52, 50, 48, 51, 54],
+        ])
     );
 }
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,54 +1,54 @@
 use approx::assert_relative_eq;
 use ndarray::{arr1, arr2, s, Array1, Axis};
 
-use ndarray_ndimage::{correlate1d, gaussian_filter, median_filter, Mask};
+use ndarray_ndimage::{correlate1d, gaussian_filter, median_filter, CorrelateMode, Mask};
 
 #[test]
 fn test_correlate1d() {
     let arr = arr1(&[2.0, 8.0, 0.0, 4.0, 1.0, 9.0, 9.0, 0.0]);
     let arr2 = arr1(&[2.0, 8.0, 0.0, 4.0, 9.0, 9.0, 0.0]);
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect),
         arr1(&[8.0, 26.0, 8.0, 12.0, 7.0, 28.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0), CorrelateMode::Reflect),
         arr1(&[24.0, 26.0, 16.0, 14.0, 25.0, 46.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0, 1.0]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0, 1.0]), Axis(0), CorrelateMode::Reflect),
         arr1(&[26.0, 24.0, 30.0, 17.0, 23.0, 34.0, 46.0, 36.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 3.0, 1.5, 0.5]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.5, 3.0, 1.5, 0.5]), Axis(0), CorrelateMode::Reflect),
         arr1(&[25.0, 21.0, 29.0, 18.5, 18.0, 27.0, 42.0, 40.5])
     );
 
     // Symmetric
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 1.0]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 1.0]), Axis(0), CorrelateMode::Reflect),
         arr1(&[16.0, 26.0, 12.0, 13.0, 16.0, 37.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr2, &arr1(&[1.5, 3.0, 1.5]), Axis(0)),
+        correlate1d(&arr2, &arr1(&[1.5, 3.0, 1.5]), Axis(0), CorrelateMode::Reflect),
         arr1(&[21.0, 27.0, 18.0, 25.5, 46.5, 40.5, 13.5])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, 2.0, 1.5]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, 2.0, 1.5]), Axis(0), CorrelateMode::Reflect),
         arr1(&[33.0, 17.0, 28.5, 29.5, 40.0, 30.5, 24.0, 45.0])
     );
 
     // Anti-symmetric
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, -1.0]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, -1.0]), Axis(0), CorrelateMode::Reflect),
         arr1(&[0.0, 26.0, 4.0, 11.0, -2.0, 19.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr2, &arr1(&[1.5, 3.0, -1.5]), Axis(0)),
+        correlate1d(&arr2, &arr1(&[1.5, 3.0, -1.5]), Axis(0), CorrelateMode::Reflect),
         arr1(&[-3.0, 27.0, 6.0, -1.5, 19.5, 40.5, 13.5])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, -2.0, -1.5]), Axis(0)),
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, -2.0, -1.5]), Axis(0), CorrelateMode::Reflect),
         arr1(&[1.0, 5.0, 9.5, -1.5, -23.0, -5.5, 24.0, 18.0])
     );
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,9 +1,59 @@
 use approx::assert_relative_eq;
-use ndarray::{arr1, arr2, s, Array1};
+use ndarray::{arr1, arr2, s, Array1, Axis};
 
-use ndarray_ndimage::{gaussian_filter, median_filter, Mask};
+use ndarray_ndimage::{correlate1d, gaussian_filter, median_filter, Mask};
 
-#[test] // Results verified manually.
+#[test]
+fn test_correlate1d() {
+    let arr = arr1(&[2.0, 8.0, 0.0, 4.0, 1.0, 9.0, 9.0, 0.0]);
+    let arr2 = arr1(&[2.0, 8.0, 0.0, 4.0, 9.0, 9.0, 0.0]);
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0)),
+        arr1(&[8.0, 26.0, 8.0, 12.0, 7.0, 28.0, 36.0, 9.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0)),
+        arr1(&[24.0, 26.0, 16.0, 14.0, 25.0, 46.0, 36.0, 9.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0, 1.0]), Axis(0)),
+        arr1(&[26.0, 24.0, 30.0, 17.0, 23.0, 34.0, 46.0, 36.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.5, 3.0, 1.5, 0.5]), Axis(0)),
+        arr1(&[25.0, 21.0, 29.0, 18.5, 18.0, 27.0, 42.0, 40.5])
+    );
+
+    // Symmetric
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 1.0]), Axis(0)),
+        arr1(&[16.0, 26.0, 12.0, 13.0, 16.0, 37.0, 36.0, 9.0])
+    );
+    assert_eq!(
+        correlate1d(&arr2, &arr1(&[1.5, 3.0, 1.5]), Axis(0)),
+        arr1(&[21.0, 27.0, 18.0, 25.5, 46.5, 40.5, 13.5])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, 2.0, 1.5]), Axis(0)),
+        arr1(&[33.0, 17.0, 28.5, 29.5, 40.0, 30.5, 24.0, 45.0])
+    );
+
+    // Anti-symmetric
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, -1.0]), Axis(0)),
+        arr1(&[0.0, 26.0, 4.0, 11.0, -2.0, 19.0, 36.0, 9.0])
+    );
+    assert_eq!(
+        correlate1d(&arr2, &arr1(&[1.5, 3.0, -1.5]), Axis(0)),
+        arr1(&[-3.0, 27.0, 6.0, -1.5, 19.5, 40.5, 13.5])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, -2.0, -1.5]), Axis(0)),
+        arr1(&[1.0, 5.0, 9.5, -1.5, -23.0, -5.5, 24.0, 18.0])
+    );
+}
+
+#[test]
 fn test_median_filter() {
     let mut gt = Mask::from_elem((3, 3, 3), false);
     let mut mask = gt.clone();

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -289,7 +289,7 @@ fn test_correlate() {
 
     let weight = arr2(&[[1, 0, 0], [0, 1, 0], [0, 0, 1]]);
     assert_eq!(
-        correlate(&a, &weight, CorrelateMode::Constant(2)),
+        correlate(&a, &weight, CorrelateMode::Constant(2), 0),
         arr2(&[
             [8, 10, 12, 14, 8],
             [18, 18, 21, 24, 14],
@@ -299,7 +299,7 @@ fn test_correlate() {
         ])
     );
     assert_eq!(
-        correlate(&a, &weight, CorrelateMode::Nearest),
+        correlate(&a, &weight, CorrelateMode::Nearest, 0),
         arr2(&[
             [6, 8, 11, 14, 16],
             [16, 18, 21, 24, 26],
@@ -309,17 +309,17 @@ fn test_correlate() {
         ])
     );
     assert_eq!(
-        correlate(&a, &weight, CorrelateMode::Mirror),
+        correlate(&a, &weight, CorrelateMode::Mirror, -1),
         arr2(&[
-            [12, 13, 16, 19, 20],
-            [17, 18, 21, 24, 25],
-            [32, 33, 36, 39, 40],
-            [47, 48, 51, 54, 55],
-            [52, 53, 56, 59, 60]
+            [18, 21, 24, 25, 24],
+            [33, 36, 39, 40, 39],
+            [48, 51, 54, 55, 54],
+            [53, 56, 59, 60, 59],
+            [48, 51, 54, 55, 54]
         ])
     );
     assert_eq!(
-        correlate(&a, &weight, CorrelateMode::Reflect),
+        correlate(&a, &weight, CorrelateMode::Reflect, 0),
         arr2(&[
             [6, 8, 11, 14, 16],
             [16, 18, 21, 24, 26],
@@ -329,19 +329,19 @@ fn test_correlate() {
         ])
     );
     assert_eq!(
-        correlate(&a, &weight, CorrelateMode::Wrap),
+        correlate(&a, &weight, CorrelateMode::Wrap, 1),
         arr2(&[
-            [30, 28, 31, 34, 32],
-            [20, 18, 21, 24, 22],
-            [35, 33, 36, 39, 37],
-            [50, 48, 51, 54, 52],
-            [40, 38, 41, 44, 42]
+            [42, 40, 38, 41, 44],
+            [32, 30, 28, 31, 34],
+            [22, 20, 18, 21, 24],
+            [37, 35, 33, 36, 39],
+            [52, 50, 48, 51, 54]
         ])
     );
 
     let weight = arr2(&[[0.0, 0.1, 0.0], [0.1, 0.9, 0.1], [0.0, 0.1, 0.0]]);
     assert_relative_eq!(
-        correlate(&a.mapv(|v| v as f32), &weight, CorrelateMode::Reflect),
+        correlate(&a.mapv(|v| v as f32), &weight, CorrelateMode::Reflect, 0),
         arr2(&[
             [0.6, 1.8, 3.1, 4.4, 5.6],
             [6.6, 7.8, 9.1, 10.4, 11.6],

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -19,6 +19,10 @@ fn test_convolve1d() {
     ]);
 
     assert_eq!(
+        convolve1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect, -1),
+        arr1(&[8.0, 14.0, 24.0, 4.0, 13.0, 12.0, 36.0, 27.0])
+    );
+    assert_eq!(
         convolve1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[14.0, 24.0, 4.0, 13.0, 12.0, 36.0, 27.0, 0.0])
     );

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -2,7 +2,7 @@ use approx::assert_relative_eq;
 use ndarray::{arr1, arr2, s, Array1, Axis};
 
 use ndarray_ndimage::{
-    convolve1d, correlate1d, gaussian_filter, median_filter, CorrelateMode, Mask,
+    convolve1d, correlate, correlate1d, gaussian_filter, median_filter, CorrelateMode, Mask,
 };
 
 #[test] // Results verified with SciPy. (v1.9.0)
@@ -279,6 +279,77 @@ fn test_correlate1d() {
     assert_eq!(
         correlate1d(&arr, &arr1(&[1.0, 0.5, 1.0, 1.5]), Axis(0), CorrelateMode::Reflect, 1),
         arr1(&[9.0, 23.0, 11.0, 12.0, 13.5, 16.5, 27.0, 14.5])
+    );
+}
+
+#[test] // Results verified with SciPy. (v1.9.0)
+fn test_correlate() {
+    let a: Array1<usize> = (0..25).collect();
+    let a = a.into_shape((5, 5)).unwrap();
+
+    let weight = arr2(&[[1, 0, 0], [0, 1, 0], [0, 0, 1]]);
+    assert_eq!(
+        correlate(&a, &weight, CorrelateMode::Constant(2)),
+        arr2(&[
+            [8, 10, 12, 14, 8],
+            [18, 18, 21, 24, 14],
+            [28, 33, 36, 39, 24],
+            [38, 48, 51, 54, 34],
+            [24, 38, 40, 42, 44]
+        ])
+    );
+    assert_eq!(
+        correlate(&a, &weight, CorrelateMode::Nearest),
+        arr2(&[
+            [6, 8, 11, 14, 16],
+            [16, 18, 21, 24, 26],
+            [31, 33, 36, 39, 41],
+            [46, 48, 51, 54, 56],
+            [56, 58, 61, 64, 66]
+        ])
+    );
+    assert_eq!(
+        correlate(&a, &weight, CorrelateMode::Mirror),
+        arr2(&[
+            [12, 13, 16, 19, 20],
+            [17, 18, 21, 24, 25],
+            [32, 33, 36, 39, 40],
+            [47, 48, 51, 54, 55],
+            [52, 53, 56, 59, 60]
+        ])
+    );
+    assert_eq!(
+        correlate(&a, &weight, CorrelateMode::Reflect),
+        arr2(&[
+            [6, 8, 11, 14, 16],
+            [16, 18, 21, 24, 26],
+            [31, 33, 36, 39, 41],
+            [46, 48, 51, 54, 56],
+            [56, 58, 61, 64, 66]
+        ])
+    );
+    assert_eq!(
+        correlate(&a, &weight, CorrelateMode::Wrap),
+        arr2(&[
+            [30, 28, 31, 34, 32],
+            [20, 18, 21, 24, 22],
+            [35, 33, 36, 39, 37],
+            [50, 48, 51, 54, 52],
+            [40, 38, 41, 44, 42]
+        ])
+    );
+
+    let weight = arr2(&[[0.0, 0.1, 0.0], [0.1, 0.9, 0.1], [0.0, 0.1, 0.0]]);
+    assert_relative_eq!(
+        correlate(&a.mapv(|v| v as f32), &weight, CorrelateMode::Reflect),
+        arr2(&[
+            [0.6, 1.8, 3.1, 4.4, 5.6],
+            [6.6, 7.8, 9.1, 10.4, 11.6],
+            [13.1, 14.3, 15.6, 16.9, 18.1],
+            [19.6, 20.8, 22.1, 23.4, 24.6],
+            [25.6, 26.8, 28.1, 29.4, 30.6]
+        ]),
+        epsilon = 1e-5
     );
 }
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -15,54 +15,55 @@ fn test_correlate1d() {
         [5.7, 4.0, 1.8, 9.1, 4.8, 2.7],
     ]);
 
+    // Non-Symmetric
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[8.0, 26.0, 8.0, 12.0, 7.0, 28.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[24.0, 26.0, 16.0, 14.0, 25.0, 46.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0, 1.0]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0, 1.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[26.0, 24.0, 30.0, 17.0, 23.0, 34.0, 46.0, 36.0])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 3.0, 1.5, 0.5]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.5, 3.0, 1.5, 0.5]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[25.0, 21.0, 29.0, 18.5, 18.0, 27.0, 42.0, 40.5])
     );
 
     // Symmetric
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, 1.0]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 1.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[16.0, 26.0, 12.0, 13.0, 16.0, 37.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr_odd, &arr1(&[1.5, 3.0, 1.5]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr_odd, &arr1(&[1.5, 3.0, 1.5]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[21.0, 27.0, 18.0, 25.5, 46.5, 40.5, 13.5])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, 2.0, 1.5]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, 2.0, 1.5]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[33.0, 17.0, 28.5, 29.5, 40.0, 30.5, 24.0, 45.0])
     );
 
     // Anti-symmetric
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.0, 3.0, -1.0]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.0, 3.0, -1.0]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[0.0, 26.0, 4.0, 11.0, -2.0, 19.0, 36.0, 9.0])
     );
     assert_eq!(
-        correlate1d(&arr_odd, &arr1(&[1.5, 3.0, -1.5]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr_odd, &arr1(&[1.5, 3.0, -1.5]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[-3.0, 27.0, 6.0, -1.5, 19.5, 40.5, 13.5])
     );
     assert_eq!(
-        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, -2.0, -1.5]), Axis(0), CorrelateMode::Reflect),
+        correlate1d(&arr, &arr1(&[1.5, 2.0, 0.5, -2.0, -1.5]), Axis(0), CorrelateMode::Reflect, 0),
         arr1(&[1.0, 5.0, 9.5, -1.5, -23.0, -5.5, 24.0, 18.0])
     );
 
     // Other modes and dimensions
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Constant(0.5)),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Constant(0.5), 0),
         arr2(&[
             [5.0, 7.4, 2.6, 3.8, 18.5, 5.6],
             [3.0, 6.2, 0.7, 1.4, 9.6, 3.8],
@@ -73,7 +74,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Constant(0.5)),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Constant(0.5), 0),
         arr2(&[
             [5.0, 8.4, 4.4, 4.0, 19.1, 11.1],
             [2.0, 4.4, 1.3, 0.3, 3.7, 3.3],
@@ -84,7 +85,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Nearest),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Nearest, 0),
         arr2(&[
             [6.0, 9.2, 2.8, 4.4, 24., 6.8],
             [3.0, 6.2, 0.7, 1.4, 9.6, 3.8],
@@ -95,7 +96,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Nearest),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Nearest, 0),
         arr2(&[
             [6.0, 8.4, 4.4, 4.0, 19.1, 11.1],
             [2.0, 4.4, 1.3, 0.3, 3.7, 3.3],
@@ -106,7 +107,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Mirror),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Mirror, 0),
         arr2(&[
             [5.0, 8.2, 2.1, 3.4, 19.2, 5.8],
             [3.0, 6.2, 0.7, 1.4, 9.6, 3.8],
@@ -117,7 +118,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Mirror),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Mirror, 0),
         arr2(&[
             [6.8, 8.4, 4.4, 4., 19.1, 11.1],
             [2.8, 4.4, 1.3, 0.3, 3.7, 3.3],
@@ -128,7 +129,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Reflect),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Reflect, 0),
         arr2(&[
             [6.0, 8.4, 4.4, 4.0, 19.1, 11.1],
             [2.0, 4.4, 1.3, 0.3, 3.7, 3.3],
@@ -139,7 +140,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Wrap),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Wrap, 0),
         arr2(&[
             [10.2, 10.9, 3.9, 12.4, 22.8, 7.8],
             [3.0, 6.2, 0.7, 1.4, 9.6, 3.8],
@@ -150,7 +151,7 @@ fn test_correlate1d() {
         epsilon = 1e-7,
     );
     assert_relative_eq!(
-        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Wrap),
+        correlate1d(&matrix, &arr1(&[1.0, 3.0]), Axis(1), CorrelateMode::Wrap, 0),
         arr2(&[
             [6.2, 8.4, 4.4, 4., 19.1, 11.1],
             [2.2, 4.4, 1.3, 0.3, 3.7, 3.3],
@@ -159,6 +160,32 @@ fn test_correlate1d() {
             [19.8, 17.7, 9.4, 29.1, 23.5, 12.9]
         ]),
         epsilon = 1e-7,
+    );
+
+    // origin != 0
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0]), Axis(0), CorrelateMode::Reflect, -1),
+        arr1(&[26.0, 8.0, 12.0, 7.0, 28.0, 36.0, 9.0, 0.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0), CorrelateMode::Reflect, -1),
+        arr1(&[26.0, 16.0, 14.0, 25.0, 46.0, 36.0, 9.0, 18.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 3.0, 2.0]), Axis(0), CorrelateMode::Reflect, 1),
+        arr1(&[18.0, 24.0, 26.0, 16.0, 14.0, 25.0, 46.0, 36.0])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 0.5, 1.0, 1.5]), Axis(0), CorrelateMode::Reflect, -2),
+        arr1(&[12.0, 13.5, 16.5, 27.0, 14.5, 13.5, 22.5, 22.5])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 0.5, 1.0, 1.5]), Axis(0), CorrelateMode::Reflect, -1),
+        arr1(&[11.0, 12.0, 13.5, 16.5, 27.0, 14.5, 13.5, 22.5])
+    );
+    assert_eq!(
+        correlate1d(&arr, &arr1(&[1.0, 0.5, 1.0, 1.5]), Axis(0), CorrelateMode::Reflect, 1),
+        arr1(&[9.0, 23.0, 11.0, 12.0, 13.5, 16.5, 27.0, 14.5])
     );
 }
 

--- a/tests/pad.rs
+++ b/tests/pad.rs
@@ -18,12 +18,12 @@ fn simple_data_3d() -> Array3<f64> {
 #[test] // Results verified with the `pad(mode='maximum')` function from NumPy. (v1.21.4)
 fn test_pad_minmax() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (2, 2), PadMode::Maximum), arr1(&[3, 3, 0, 1, 2, 3, 3, 3]));
-    assert_eq!(pad(&data, (2, 2), PadMode::Minimum), arr1(&[0, 0, 0, 1, 2, 3, 0, 0]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Maximum), arr1(&[3, 3, 0, 1, 2, 3, 3, 3]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Minimum), arr1(&[0, 0, 0, 1, 2, 3, 0, 0]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Maximum),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Maximum),
         arr2(&[
             [11.0, 11.0, 8.0, 9.0, 10.0, 11.0, 11.0, 11.0],
             [3.0, 3.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
@@ -33,7 +33,7 @@ fn test_pad_minmax() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Minimum),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Minimum),
         arr2(&[
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
@@ -45,7 +45,7 @@ fn test_pad_minmax() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Maximum),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Maximum),
         arr3(&[
             [
                 [11.0, 11.0, 8.0, 9.0, 10.0, 11.0, 11.0, 11.0],
@@ -64,7 +64,7 @@ fn test_pad_minmax() {
         ])
     );
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Minimum),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Minimum),
         arr3(&[
             [
                 [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
@@ -87,12 +87,12 @@ fn test_pad_minmax() {
 #[test] // Results verified with the `pad(mode='mean')` function from NumPy. (v1.21.4)
 fn test_pad_mean() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (2, 2), PadMode::Mean), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
-    assert_eq!(pad(&arr1(&[1, 2, 3]), (2, 2), PadMode::Mean), arr1(&[2, 2, 1, 2, 3, 2, 2]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Mean), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
+    assert_eq!(pad(&arr1(&[1, 2, 3]), &[[2, 2]], PadMode::Mean), arr1(&[2, 2, 1, 2, 3, 2, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Mean),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Mean),
         arr2(&[
             [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
             [1.5, 1.5, 0.0, 1.0, 2.0, 3.0, 1.5, 1.5],
@@ -104,7 +104,7 @@ fn test_pad_mean() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Mean),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Mean),
         arr3(&[
             [
                 [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
@@ -127,12 +127,12 @@ fn test_pad_mean() {
 #[test] // Results verified with the `pad(mode='median')` function from NumPy. (v1.21.4)
 fn test_pad_median() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (2, 2), PadMode::Median), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
-    assert_eq!(pad(&arr1(&[1, 2, 3]), (2, 2), PadMode::Median), arr1(&[2, 2, 1, 2, 3, 2, 2]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Median), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
+    assert_eq!(pad(&arr1(&[1, 2, 3]), &[[2, 2]], PadMode::Median), arr1(&[2, 2, 1, 2, 3, 2, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Median),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Median),
         arr2(&[
             [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
             [1.5, 1.5, 0.0, 1.0, 2.0, 3.0, 1.5, 1.5],
@@ -144,7 +144,7 @@ fn test_pad_median() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Median),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Median),
         arr3(&[
             [
                 [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
@@ -167,12 +167,12 @@ fn test_pad_median() {
 #[test] // Results verified with the `pad(mode='reflect')` function from NumPy. (v1.21.4)
 fn test_pad_reflect() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (1, 1), PadMode::Reflect), arr1(&[1, 0, 1, 2, 3, 2]));
-    assert_eq!(pad(&data, (2, 2), PadMode::Reflect), arr1(&[2, 1, 0, 1, 2, 3, 2, 1]));
+    assert_eq!(pad(&data, &[[1, 1]], PadMode::Reflect), arr1(&[1, 0, 1, 2, 3, 2]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Reflect), arr1(&[2, 1, 0, 1, 2, 3, 2, 1]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 1), (1, 1)), PadMode::Reflect),
+        pad(&data, &[[1, 1], [1, 1],], PadMode::Reflect),
         arr2(&[
             [5.0, 4.0, 5.0, 6.0, 7.0, 6.0],
             [1.0, 0.0, 1.0, 2.0, 3.0, 2.0],
@@ -182,7 +182,7 @@ fn test_pad_reflect() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Reflect),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Reflect),
         arr2(&[
             [6.0, 5.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0],
             [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 2.0, 1.0],
@@ -194,7 +194,7 @@ fn test_pad_reflect() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Reflect),
+        pad(&data, &[[1, 1], [1, 1], [1, 1]], PadMode::Reflect),
         arr3(&[
             [
                 [17.0, 16.0, 17.0, 18.0, 19.0, 18.0],
@@ -227,7 +227,7 @@ fn test_pad_reflect() {
         ])
     );
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Reflect),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Reflect),
         arr3(&[
             [
                 [6.0, 5.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0],
@@ -250,12 +250,12 @@ fn test_pad_reflect() {
 #[test] // Results verified with the `pad(mode='symmetric')` function from NumPy. (v1.21.4)
 fn test_pad_symmetric() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (1, 1), PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3, 3]));
-    assert_eq!(pad(&data, (2, 2), PadMode::Symmetric), arr1(&[1, 0, 0, 1, 2, 3, 3, 2]));
+    assert_eq!(pad(&data, &[[1, 1]], PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3, 3]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Symmetric), arr1(&[1, 0, 0, 1, 2, 3, 3, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 1), (1, 1)), PadMode::Symmetric),
+        pad(&data, &[[1, 1], [1, 1],], PadMode::Symmetric),
         arr2(&[
             [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
             [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
@@ -265,7 +265,7 @@ fn test_pad_symmetric() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Symmetric),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Symmetric),
         arr2(&[
             [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
             [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
@@ -277,7 +277,7 @@ fn test_pad_symmetric() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Symmetric),
+        pad(&data, &[[1, 1], [1, 1], [1, 1]], PadMode::Symmetric),
         arr3(&[
             [
                 [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
@@ -310,7 +310,7 @@ fn test_pad_symmetric() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((0, 1, 2), (0, 1, 2)), PadMode::Symmetric),
+        pad(&data, &[[0, 0], [1, 1], [2, 2]], PadMode::Symmetric),
         arr3(&[
             [
                 [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
@@ -333,12 +333,12 @@ fn test_pad_symmetric() {
 #[test] // Results verified with the `pad(mode='wrap')` function from NumPy. (v1.21.4)
 fn test_pad_wrap() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (1, 1), PadMode::Wrap), arr1(&[3, 0, 1, 2, 3, 0]));
-    assert_eq!(pad(&data, (2, 2), PadMode::Wrap), arr1(&[2, 3, 0, 1, 2, 3, 0, 1]));
+    assert_eq!(pad(&data, &[[1, 1]], PadMode::Wrap), arr1(&[3, 0, 1, 2, 3, 0]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Wrap), arr1(&[2, 3, 0, 1, 2, 3, 0, 1]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 1), (1, 1)), PadMode::Wrap),
+        pad(&data, &[[1, 1], [1, 1],], PadMode::Wrap),
         arr2(&[
             [11.0, 8.0, 9.0, 10.0, 11.0, 8.0],
             [3.0, 0.0, 1.0, 2.0, 3.0, 0.0],
@@ -348,7 +348,7 @@ fn test_pad_wrap() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Wrap),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Wrap),
         arr2(&[
             [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0, 9.0],
             [2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0],
@@ -360,7 +360,7 @@ fn test_pad_wrap() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Wrap),
+        pad(&data, &[[1, 1], [1, 1], [1, 1]], PadMode::Wrap),
         arr3(&[
             [
                 [23.0, 20.0, 21.0, 22.0, 23.0, 20.0],
@@ -393,7 +393,7 @@ fn test_pad_wrap() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, ((0, 1, 2), (0, 1, 2)), PadMode::Wrap),
+        pad(&data, &[[0, 0], [1, 1], [2, 2]], PadMode::Wrap),
         arr3(&[
             [
                 [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0, 9.0],
@@ -416,11 +416,11 @@ fn test_pad_wrap() {
 #[test] // Results verified with the `pad(mode='median')` function from NumPy. (v1.21.4)
 fn test_pad_edge() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, (2, 2), PadMode::Edge), arr1(&[0, 0, 0, 1, 2, 3, 3, 3]));
+    assert_eq!(pad(&data, &[[2, 2]], PadMode::Edge), arr1(&[0, 0, 0, 1, 2, 3, 3, 3]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, ((1, 2), (1, 2)), PadMode::Edge),
+        pad(&data, &[[1, 1], [2, 2]], PadMode::Edge),
         arr2(&[
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
@@ -432,7 +432,7 @@ fn test_pad_edge() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Edge),
+        pad(&data.view(), &[[0, 0], [1, 1], [2, 2]], PadMode::Edge),
         arr3(&[
             [
                 [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],

--- a/tests/pad.rs
+++ b/tests/pad.rs
@@ -18,12 +18,12 @@ fn simple_data_3d() -> Array3<f64> {
 #[test] // Results verified with the `pad(mode='maximum')` function from NumPy. (v1.21.4)
 fn test_pad_minmax() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 2, PadMode::Maximum), arr1(&[3, 3, 0, 1, 2, 3, 3, 3]));
-    assert_eq!(pad(&data, 2, PadMode::Minimum), arr1(&[0, 0, 0, 1, 2, 3, 0, 0]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Maximum), arr1(&[3, 3, 0, 1, 2, 3, 3, 3]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Minimum), arr1(&[0, 0, 0, 1, 2, 3, 0, 0]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Maximum),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Maximum),
         arr2(&[
             [11.0, 11.0, 8.0, 9.0, 10.0, 11.0, 11.0, 11.0],
             [3.0, 3.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
@@ -33,7 +33,7 @@ fn test_pad_minmax() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Minimum),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Minimum),
         arr2(&[
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
@@ -45,7 +45,7 @@ fn test_pad_minmax() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Maximum),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Maximum),
         arr3(&[
             [
                 [11.0, 11.0, 8.0, 9.0, 10.0, 11.0, 11.0, 11.0],
@@ -64,7 +64,7 @@ fn test_pad_minmax() {
         ])
     );
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Minimum),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Minimum),
         arr3(&[
             [
                 [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 0.0],
@@ -87,12 +87,12 @@ fn test_pad_minmax() {
 #[test] // Results verified with the `pad(mode='mean')` function from NumPy. (v1.21.4)
 fn test_pad_mean() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 2, PadMode::Mean), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
-    assert_eq!(pad(&arr1(&[1, 2, 3]), 2, PadMode::Mean), arr1(&[2, 2, 1, 2, 3, 2, 2]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Mean), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
+    assert_eq!(pad(&arr1(&[1, 2, 3]), (2, 2), PadMode::Mean), arr1(&[2, 2, 1, 2, 3, 2, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Mean),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Mean),
         arr2(&[
             [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
             [1.5, 1.5, 0.0, 1.0, 2.0, 3.0, 1.5, 1.5],
@@ -104,7 +104,7 @@ fn test_pad_mean() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Mean),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Mean),
         arr3(&[
             [
                 [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
@@ -127,12 +127,12 @@ fn test_pad_mean() {
 #[test] // Results verified with the `pad(mode='median')` function from NumPy. (v1.21.4)
 fn test_pad_median() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 2, PadMode::Median), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
-    assert_eq!(pad(&arr1(&[1, 2, 3]), 2, PadMode::Median), arr1(&[2, 2, 1, 2, 3, 2, 2]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Median), arr1(&[1, 1, 0, 1, 2, 3, 1, 1]));
+    assert_eq!(pad(&arr1(&[1, 2, 3]), (2, 2), PadMode::Median), arr1(&[2, 2, 1, 2, 3, 2, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Median),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Median),
         arr2(&[
             [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
             [1.5, 1.5, 0.0, 1.0, 2.0, 3.0, 1.5, 1.5],
@@ -144,7 +144,7 @@ fn test_pad_median() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Median),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Median),
         arr3(&[
             [
                 [5.5, 5.5, 4.0, 5.0, 6.0, 7.0, 5.5, 5.5],
@@ -167,12 +167,12 @@ fn test_pad_median() {
 #[test] // Results verified with the `pad(mode='reflect')` function from NumPy. (v1.21.4)
 fn test_pad_reflect() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 1, PadMode::Reflect), arr1(&[1, 0, 1, 2, 3, 2]));
-    assert_eq!(pad(&data, 2, PadMode::Reflect), arr1(&[2, 1, 0, 1, 2, 3, 2, 1]));
+    assert_eq!(pad(&data, (1, 1), PadMode::Reflect), arr1(&[1, 0, 1, 2, 3, 2]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Reflect), arr1(&[2, 1, 0, 1, 2, 3, 2, 1]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 1), PadMode::Reflect),
+        pad(&data, ((1, 1), (1, 1)), PadMode::Reflect),
         arr2(&[
             [5.0, 4.0, 5.0, 6.0, 7.0, 6.0],
             [1.0, 0.0, 1.0, 2.0, 3.0, 2.0],
@@ -182,7 +182,7 @@ fn test_pad_reflect() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Reflect),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Reflect),
         arr2(&[
             [6.0, 5.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0],
             [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 2.0, 1.0],
@@ -194,7 +194,7 @@ fn test_pad_reflect() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, (1, 1, 1), PadMode::Reflect),
+        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Reflect),
         arr3(&[
             [
                 [17.0, 16.0, 17.0, 18.0, 19.0, 18.0],
@@ -227,7 +227,7 @@ fn test_pad_reflect() {
         ])
     );
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Reflect),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Reflect),
         arr3(&[
             [
                 [6.0, 5.0, 4.0, 5.0, 6.0, 7.0, 6.0, 5.0],
@@ -250,12 +250,12 @@ fn test_pad_reflect() {
 #[test] // Results verified with the `pad(mode='symmetric')` function from NumPy. (v1.21.4)
 fn test_pad_symmetric() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 1, PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3, 3]));
-    assert_eq!(pad(&data, 2, PadMode::Symmetric), arr1(&[1, 0, 0, 1, 2, 3, 3, 2]));
+    assert_eq!(pad(&data, (1, 1), PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3, 3]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Symmetric), arr1(&[1, 0, 0, 1, 2, 3, 3, 2]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 1), PadMode::Symmetric),
+        pad(&data, ((1, 1), (1, 1)), PadMode::Symmetric),
         arr2(&[
             [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
             [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
@@ -265,7 +265,7 @@ fn test_pad_symmetric() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Symmetric),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Symmetric),
         arr2(&[
             [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
             [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
@@ -277,7 +277,7 @@ fn test_pad_symmetric() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, (1, 1, 1), PadMode::Symmetric),
+        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Symmetric),
         arr3(&[
             [
                 [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
@@ -310,7 +310,7 @@ fn test_pad_symmetric() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (0, 1, 2), PadMode::Symmetric),
+        pad(&data, ((0, 1, 2), (0, 1, 2)), PadMode::Symmetric),
         arr3(&[
             [
                 [1.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
@@ -333,12 +333,12 @@ fn test_pad_symmetric() {
 #[test] // Results verified with the `pad(mode='wrap')` function from NumPy. (v1.21.4)
 fn test_pad_wrap() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 1, PadMode::Wrap), arr1(&[3, 0, 1, 2, 3, 0]));
-    assert_eq!(pad(&data, 2, PadMode::Wrap), arr1(&[2, 3, 0, 1, 2, 3, 0, 1]));
+    assert_eq!(pad(&data, (1, 1), PadMode::Wrap), arr1(&[3, 0, 1, 2, 3, 0]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Wrap), arr1(&[2, 3, 0, 1, 2, 3, 0, 1]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 1), PadMode::Wrap),
+        pad(&data, ((1, 1), (1, 1)), PadMode::Wrap),
         arr2(&[
             [11.0, 8.0, 9.0, 10.0, 11.0, 8.0],
             [3.0, 0.0, 1.0, 2.0, 3.0, 0.0],
@@ -348,7 +348,7 @@ fn test_pad_wrap() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Wrap),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Wrap),
         arr2(&[
             [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0, 9.0],
             [2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0],
@@ -360,7 +360,7 @@ fn test_pad_wrap() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data, (1, 1, 1), PadMode::Wrap),
+        pad(&data, ((1, 1, 1), (1, 1, 1)), PadMode::Wrap),
         arr3(&[
             [
                 [23.0, 20.0, 21.0, 22.0, 23.0, 20.0],
@@ -393,7 +393,7 @@ fn test_pad_wrap() {
         ])
     );
     assert_relative_eq!(
-        pad(&data, (0, 1, 2), PadMode::Wrap),
+        pad(&data, ((0, 1, 2), (0, 1, 2)), PadMode::Wrap),
         arr3(&[
             [
                 [10.0, 11.0, 8.0, 9.0, 10.0, 11.0, 8.0, 9.0],
@@ -416,11 +416,11 @@ fn test_pad_wrap() {
 #[test] // Results verified with the `pad(mode='median')` function from NumPy. (v1.21.4)
 fn test_pad_edge() {
     let data = simple_data_1d();
-    assert_eq!(pad(&data, 2, PadMode::Edge), arr1(&[0, 0, 0, 1, 2, 3, 3, 3]));
+    assert_eq!(pad(&data, (2, 2), PadMode::Edge), arr1(&[0, 0, 0, 1, 2, 3, 3, 3]));
 
     let data = simple_data_2d();
     assert_relative_eq!(
-        pad(&data, (1, 2), PadMode::Edge),
+        pad(&data, ((1, 2), (1, 2)), PadMode::Edge),
         arr2(&[
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
             [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
@@ -432,7 +432,7 @@ fn test_pad_edge() {
 
     let data = simple_data_3d();
     assert_relative_eq!(
-        pad(&data.view(), (0, 1, 2), PadMode::Edge),
+        pad(&data.view(), ((0, 1, 2), (0, 1, 2)), PadMode::Edge),
         arr3(&[
             [
                 [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],


### PR DESCRIPTION
This PR contains `correlate`, `correlate1d`, `convolve` and `convolve1d`. I had to modify `pad` a little to:

- add a `pad_to` function to avoid allocating
- add a left pad and right pad `[usize; 2]` given in a vector

The Symmetry thing is not super useful in this Rust version! We're only slightly faster with a Symmetric ot AntiSymmetric kernel. In SciPy, there's an immense gain, but not here.

Benchmarking the SciPy version seems quite random. I had results going from 30ms to 60ms. This Rust version is slower than the best SciPy time, but faster than the worst and the mean. I'm not sure which time to use.

As for the `correlate` and `convolve` functions, I can say at last that this version is faster than SciPy! If we ever make `pad` faster, this will make all other functions faster...

My only problem with this PR is that `convolve1d` and `correlate1d` only support Float datatypes. I'm still searching how to support all datatypes.