### PR TITLE
Morphology

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This crate provides multidimensional image processing for [`ndarray`]'s `ArrayBa
 
 It aims to:
 - be a Rust replacement for [`scipy.ndimage`] with some other tools like [`numpy.pad`] and anything else relevant to image processing. We do not want all options and arguments offered by `scipy.ndimage` because some of them are incompatible with Rust. We hope to offer the most used ones.
-- be faster or as fast as `scipy.ndimage`. Most of it is cythonized so it's not as easy as it seems.
+- be faster or as fast as `scipy.ndimage`. Most of it is cythonized so it's not as easy as it seems. In fact, I'm usually unable to be faster than SciPy but it does happen on some functions.
 - avoid using `unsafe`. This is not an unbreakable rule. Its usage will be evaluated and dicussed in the pull requests.
 
 Currently available routines include:
@@ -13,7 +13,7 @@ Currently available routines include:
 - Fourier filters: none. Please use the excellent [`rustfft`] crate
 - Interpolation: spline_filter/1d
 - Measurements: label, label_histogram, largest_connected_components, most_frequent_label
-- Morphology: binary_dilation, binary_erosion
+- Morphology: binary_closing, binary_dilation, binary_erosion, binary_opening
 - Padding: Almost all modes. Work for all dimensions and types.
 
 **This crate is a work-in-progress.** Only a subset of the `scipy.ndimage` functions are provided and most of them offer less options than SciPy. Some are offered only in 3D, with less boundary modes, with only 2 types of structuring element, only for binary data, only for f64, etc.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,7 +3,7 @@ use ndarray::{
 };
 use num_traits::{Float, FromPrimitive, Num, ToPrimitive};
 
-use crate::{array_like, dim_minus_1, pad, pad_to, Mask, PadMode};
+use crate::{array_like, dim_minus, pad, pad_to, Mask, PadMode};
 
 // TODO We might want to offer all NumPy mode (use PadMode instead)
 /// Method that will be used to determines how the input array is extended beyond its boundaries.
@@ -361,7 +361,7 @@ where
         }
     };
 
-    let (width, height, depth) = dim_minus_1(mask);
+    let (width, height, depth) = dim_minus(mask, 1);
     let ranges_x: Vec<_> = (0..=width).map(|x| range(x, width)).collect();
     let ranges_y: Vec<_> = (0..=height).map(|y| range(y, height)).collect();
     let ranges_z: Vec<_> = (0..=depth).map(|z| range(z, depth)).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use filters::{
 };
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};
-pub use morphology::{binary_dilation, binary_erosion, binary_opening};
+pub use morphology::{binary_closing, binary_dilation, binary_erosion, binary_opening};
 pub use pad::{pad, pad_to, PadMode};
 
 /// 3D mask

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use filters::{
 };
 pub use interpolation::{spline_filter, spline_filter1d};
 pub use measurements::{label, label_histogram, largest_connected_components, most_frequent_label};
-pub use morphology::{binary_dilation, binary_erosion};
+pub use morphology::{binary_dilation, binary_erosion, binary_opening};
 pub use pad::{pad, pad_to, PadMode};
 
 /// 3D mask

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,11 @@ where
 }
 
 /// Utilitary function that returns the mask dimension minus 1 on all dimensions.
-pub fn dim_minus_1<S, A>(mask: &ArrayBase<S, Ix3>) -> (usize, usize, usize)
+pub fn dim_minus<S, A>(mask: &ArrayBase<S, Ix3>, n: usize) -> (usize, usize, usize)
 where
     S: Data<Elem = A>,
     A: Clone,
 {
     let (width, height, depth) = mask.dim();
-    (width - 1, height - 1, depth - 1)
+    (width - n, height - n, depth - n)
 }

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -1,41 +1,62 @@
-use ndarray::{s, Array3, ArrayBase, Data, Ix3, Zip};
+use ndarray::{s, ArrayBase, ArrayView3, ArrayViewMut3, Data, Ix3, Zip};
 
-use crate::{array_like, dim_minus_1, Kernel3d, Mask};
+use crate::{array_like, dim_minus, Kernel3d, Mask};
 
 /// Binary erosion of a 3D binary image.
 ///
 /// * `mask` - Binary image to be eroded.
 /// * `kernel` - Structuring element used for the erosion.
-pub fn binary_erosion<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d) -> Mask
+/// * `iterations` - The erosion is repeated iterations times.
+pub fn binary_erosion<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations: usize) -> Mask
 where
     S: Data<Elem = bool>,
 {
+    // Erode the mask when at least one of the values doesn't respect the kernel.
+    // An erosion is defined either as `all(!(!w & k))` or `!any(!w & k)`.
+    // An empty kernel will always produce a full mask.
+    let erode = |from: ArrayView3<bool>, into: ArrayViewMut3<bool>| {
+        if kernel == Kernel3d::Full {
+            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| !w.iter().any(|w| !w));
+        } else {
+            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
+                // This ugly condition is equivalent to
+                // *mask = !w.iter().zip(&kernel).any(|(w, k)| !w & k)
+                // but it's around 5x faster because there's no branch misprediction
+                !(!w[(0, 1, 1)]
+                    || !w[(1, 0, 1)]
+                    || !w[(1, 1, 0)]
+                    || !w[(1, 1, 1)]
+                    || !w[(1, 1, 2)]
+                    || !w[(1, 2, 1)]
+                    || !w[(2, 1, 1)])
+            });
+        }
+    };
+
     // By definition, all borders are set to 0
-    let (width, height, depth) = dim_minus_1(mask);
-    let mut eroded_mask = Array3::from_elem(mask.dim(), false);
+    let (width, height, depth) = dim_minus(mask, 1);
+    let mut eroded_mask = Mask::from_elem(mask.dim(), false);
     let zone = s![1..width, 1..height, 1..depth];
     eroded_mask.slice_mut(zone).assign(&mask.slice(zone));
 
-    // Erode the mask when at least one of the values doesn't respect the kernel.
-    // An erosion is defined either as `all(!(!w & k))` or `!any(!w & k)`.
-    // Note that an empty kernel will always produce a full mask.
-    let zone = eroded_mask.slice_mut(s![1..width, 1..height, 1..depth]);
-    if kernel == Kernel3d::Full {
-        Zip::from(mask.windows((3, 3, 3))).map_assign_into(zone, |w| !w.iter().any(|w| !w));
-    } else {
-        Zip::from(mask.windows((3, 3, 3))).map_assign_into(zone, |w| {
-            // This ugly condition is equivalent to
-            // *mask = !w.iter().zip(&kernel).any(|(w, k)| !w & k)
-            // but it's around 5x faster because there's no branch misprediction
-            !(!w[(0, 1, 1)]
-                || !w[(1, 0, 1)]
-                || !w[(1, 1, 0)]
-                || !w[(1, 1, 1)]
-                || !w[(1, 1, 2)]
-                || !w[(1, 2, 1)]
-                || !w[(2, 1, 1)])
-        });
+    erode(mask.view(), eroded_mask.slice_mut(zone));
+
+    if iterations > 1 {
+        let mut previous = eroded_mask.clone();
+        for it in 1..iterations {
+            let (width, height, depth) = dim_minus(mask, it - 1);
+            let from = previous.slice(s![it - 1..width, it - 1..height, it - 1..depth]);
+            let (width, height, depth) = dim_minus(mask, it);
+            let zone = s![it..width, it..height, it..depth];
+
+            erode(from, eroded_mask.slice_mut(zone));
+
+            if it != iterations {
+                previous = eroded_mask.clone();
+            }
+        }
     }
+
     eroded_mask
 }
 

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -64,7 +64,7 @@ where
 ///
 /// * `mask` - Binary image to be dilated.
 /// * `kernel` - Structuring element used for the dilation.
-/// * `iterations` - The erosion is repeated iterations times.
+/// * `iterations` - The dilation is repeated iterations times.
 pub fn binary_dilation<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations: usize) -> Mask
 where
     S: Data<Elem = bool>,
@@ -103,4 +103,21 @@ where
     }
 
     new_mask.slice(crop).to_owned()
+}
+
+/// Binary opening of a 3D binary image.
+///
+/// The opening of an input image by a structuring element is the dilation of the erosion of the
+/// image by the structuring element.
+///
+/// * `mask` - Binary image to be opened.
+/// * `kernel` - Structuring element used for the opening.
+/// * `iterations` - The erosion step of the opening, then the dilation step are each repeated
+///   iterations times.
+pub fn binary_opening<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations: usize) -> Mask
+where
+    S: Data<Elem = bool>,
+{
+    let eroded = binary_erosion(mask, kernel, iterations);
+    binary_dilation(&eroded, kernel, iterations)
 }

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -2,6 +2,83 @@ use ndarray::{s, ArrayBase, ArrayView3, ArrayViewMut3, Data, Ix3, Zip};
 
 use crate::{array_like, dim_minus, Kernel3d, Mask};
 
+impl Kernel3d {
+    /// Erode the mask when at least one of the values doesn't respect the kernel.
+    ///
+    /// An erosion is defined either as `all(!(!w & k))` or `!any(!w & k)`. Thus, an empty kernel
+    /// will always produce a full mask.
+    #[rustfmt::skip]
+    fn erode(&self, from: ArrayView3<bool>, into: ArrayViewMut3<bool>) {
+        match *self {
+            Kernel3d::Full => {
+                // TODO This is incredibly ugly but this is much faster (3x) than the Zip
+                //Zip::from(from.windows((3, 3, 3)))
+                //    .map_assign_into(into, |w| Zip::from(w).all(|&m| m));
+                Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
+                    w[(0, 0, 0)] && w[(0, 0, 1)] && w[(0, 0, 2)]
+                 && w[(0, 1, 0)] && w[(0, 1, 1)] && w[(0, 1, 2)]
+                 && w[(0, 2, 0)] && w[(0, 2, 1)] && w[(0, 2, 2)]
+                 && w[(1, 0, 0)] && w[(1, 0, 1)] && w[(1, 0, 2)]
+                 && w[(1, 1, 0)] && w[(1, 1, 1)] && w[(1, 1, 2)]
+                 && w[(1, 2, 0)] && w[(1, 2, 1)] && w[(1, 2, 2)]
+                 && w[(2, 0, 0)] && w[(2, 0, 1)] && w[(2, 0, 2)]
+                 && w[(2, 1, 0)] && w[(2, 1, 1)] && w[(2, 1, 2)]
+                 && w[(2, 2, 0)] && w[(2, 2, 1)] && w[(2, 2, 2)]
+                })
+            }
+            Kernel3d::Star => Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
+                // This ugly condition is equivalent to
+                // *mask = !w.iter().zip(&kernel).any(|(w, k)| !w & k)
+                // but it's around 5x faster because there's no branch misprediction
+                w[(0, 1, 1)]
+                    && w[(1, 0, 1)]
+                    && w[(1, 1, 0)]
+                    && w[(1, 1, 1)]
+                    && w[(1, 1, 2)]
+                    && w[(1, 2, 1)]
+                    && w[(2, 1, 1)]
+            }),
+        }
+    }
+
+    /// Dilate the mask when at least one of the values respect the kernel:
+    ///
+    /// A dilation is defined as `any(w & k)`. Thus, an empty kernel will always produce an empty
+    /// mask.
+    #[rustfmt::skip]
+    fn dilate(&self, from: ArrayView3<bool>, into: ArrayViewMut3<bool>) {
+        match *self {
+            Kernel3d::Full => {
+                // TODO This is incredibly ugly but this is much faster (6x) than the Zip
+                //Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| w.iter().any(|&w| w))
+                Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
+                    w[(0, 0, 0)] || w[(0, 0, 1)] || w[(0, 0, 2)]
+                 || w[(0, 1, 0)] || w[(0, 1, 1)] || w[(0, 1, 2)]
+                 || w[(0, 2, 0)] || w[(0, 2, 1)] || w[(0, 2, 2)]
+                 || w[(1, 0, 0)] || w[(1, 0, 1)] || w[(1, 0, 2)]
+                 || w[(1, 1, 0)] || w[(1, 1, 1)] || w[(1, 1, 2)]
+                 || w[(1, 2, 0)] || w[(1, 2, 1)] || w[(1, 2, 2)]
+                 || w[(2, 0, 0)] || w[(2, 0, 1)] || w[(2, 0, 2)]
+                 || w[(2, 1, 0)] || w[(2, 1, 1)] || w[(2, 1, 2)]
+                 || w[(2, 2, 0)] || w[(2, 2, 1)] || w[(2, 2, 2)]
+                })
+            }
+            Kernel3d::Star => Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
+                // This ugly condition is equivalent to
+                // *mask = w.iter().zip(&kernel).any(|(w, k)| w & k)
+                // but it's around 5x faster because there's no branch misprediction
+                w[(0, 1, 1)]
+                    || w[(1, 0, 1)]
+                    || w[(1, 1, 0)]
+                    || w[(1, 1, 1)]
+                    || w[(1, 1, 2)]
+                    || w[(1, 2, 1)]
+                    || w[(2, 1, 1)]
+            }),
+        }
+    }
+}
+
 /// Binary erosion of a 3D binary image.
 ///
 /// * `mask` - Binary image to be eroded.
@@ -11,35 +88,13 @@ pub fn binary_erosion<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations:
 where
     S: Data<Elem = bool>,
 {
-    // Erode the mask when at least one of the values doesn't respect the kernel.
-    // An erosion is defined either as `all(!(!w & k))` or `!any(!w & k)`.
-    // An empty kernel will always produce a full mask.
-    let erode = |from: ArrayView3<bool>, into: ArrayViewMut3<bool>| {
-        if kernel == Kernel3d::Full {
-            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| !w.iter().any(|w| !w));
-        } else {
-            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
-                // This ugly condition is equivalent to
-                // *mask = !w.iter().zip(&kernel).any(|(w, k)| !w & k)
-                // but it's around 5x faster because there's no branch misprediction
-                !(!w[(0, 1, 1)]
-                    || !w[(1, 0, 1)]
-                    || !w[(1, 1, 0)]
-                    || !w[(1, 1, 1)]
-                    || !w[(1, 1, 2)]
-                    || !w[(1, 2, 1)]
-                    || !w[(2, 1, 1)])
-            });
-        }
-    };
-
     // By definition, all borders are set to 0
     let (width, height, depth) = dim_minus(mask, 1);
     let mut eroded_mask = Mask::from_elem(mask.dim(), false);
     let zone = s![1..width, 1..height, 1..depth];
     eroded_mask.slice_mut(zone).assign(&mask.slice(zone));
 
-    erode(mask.view(), eroded_mask.slice_mut(zone));
+    kernel.erode(mask.view(), eroded_mask.slice_mut(zone));
 
     if iterations > 1 {
         let mut previous = eroded_mask.clone();
@@ -49,7 +104,7 @@ where
             let (width, height, depth) = dim_minus(mask, it);
             let zone = s![it..width, it..height, it..depth];
 
-            erode(from, eroded_mask.slice_mut(zone));
+            kernel.erode(from, eroded_mask.slice_mut(zone));
 
             if it != iterations {
                 previous = eroded_mask.clone();
@@ -69,37 +124,17 @@ pub fn binary_dilation<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations
 where
     S: Data<Elem = bool>,
 {
-    // Dilate the mask when at least one of the values respect the kernel: `any(w & k)`.
-    // Note that an empty kernel will always produce an empty mask.
-    let dilate = |from: ArrayView3<bool>, into: ArrayViewMut3<bool>| {
-        if kernel == Kernel3d::Full {
-            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| w.iter().any(|&w| w));
-        } else {
-            Zip::from(from.windows((3, 3, 3))).map_assign_into(into, |w| {
-                // This ugly condition is equivalent to
-                // *mask = w.iter().zip(&kernel).any(|(w, k)| w & k)
-                // but it's around 5x faster because there's no branch misprediction
-                w[(0, 1, 1)]
-                    || w[(1, 0, 1)]
-                    || w[(1, 1, 0)]
-                    || w[(1, 1, 1)]
-                    || w[(1, 1, 2)]
-                    || w[(1, 2, 1)]
-                    || w[(2, 1, 1)]
-            });
-        }
-    };
     let (width, height, depth) = mask.dim();
     let crop = s![1..=width, 1..=height, 1..=depth];
     let mut new_mask = array_like(mask, (width + 2, height + 2, depth + 2), false);
     new_mask.slice_mut(crop).assign(mask);
 
     let mut previous = new_mask.clone();
-    dilate(previous.view(), new_mask.slice_mut(crop));
+    kernel.dilate(previous.view(), new_mask.slice_mut(crop));
 
     for _ in 1..iterations {
         previous = new_mask.clone();
-        dilate(previous.view(), new_mask.slice_mut(crop));
+        kernel.dilate(previous.view(), new_mask.slice_mut(crop));
     }
 
     new_mask.slice(crop).to_owned()

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -121,3 +121,20 @@ where
     let eroded = binary_erosion(mask, kernel, iterations);
     binary_dilation(&eroded, kernel, iterations)
 }
+
+/// Binary closing of a 3D binary image.
+///
+/// The closing of an input image by a structuring element is the erosion of the dilation of the
+/// image by the structuring element.
+///
+/// * `mask` - Binary image to be closed.
+/// * `kernel` - Structuring element used for the closing.
+/// * `iterations` - The dilation step of the closing, then the erosion step are each repeated
+///   iterations times.
+pub fn binary_closing<S>(mask: &ArrayBase<S, Ix3>, kernel: Kernel3d, iterations: usize) -> Mask
+where
+    S: Data<Elem = bool>,
+{
+    let dilated = binary_dilation(mask, kernel, iterations);
+    binary_erosion(&dilated, kernel, iterations)
+}

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -95,7 +95,19 @@ fn test_binary_dilation_plain() {
     gt.slice_mut(s![2..w - 1, 2..h - 1, 1..d]).fill(true);
     gt.slice_mut(s![2..w - 1, h - 1, 2..d - 1]).fill(true);
 
-    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Star));
+    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Star, 1));
+
+    let mut mask = Mask::from_elem((w, h, d), false);
+    mask[(4, 4, 4)] = true;
+    let mut gt = Mask::from_elem((w, h, d), false);
+    gt.slice_mut(s![2.., 2.., 2..]).fill(true);
+    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Full, 2));
+
+    let mut mask = Mask::from_elem((w, h, d), false);
+    mask[(4, 5, 5)] = true;
+    let mut gt = Mask::from_elem((w, h, d), false);
+    gt.slice_mut(s![1.., 2.., 2..]).fill(true);
+    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Full, 3));
 }
 
 #[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)
@@ -106,5 +118,5 @@ fn test_binary_dilation_corner() {
     let mut gt = Mask::from_elem((11, 11, 11), true);
     gt.slice_mut(s![8.., 8.., 8..]).fill(false);
 
-    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Full));
+    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Full, 1));
 }

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -1,6 +1,6 @@
 use ndarray::s;
 
-use ndarray_ndimage::{binary_dilation, binary_erosion, dim_minus, Kernel3d, Mask};
+use ndarray_ndimage::{binary_dilation, binary_erosion, binary_opening, dim_minus, Kernel3d, Mask};
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
 fn test_binary_erosion() {
@@ -119,4 +119,16 @@ fn test_binary_dilation_corner() {
     gt.slice_mut(s![8.., 8.., 8..]).fill(false);
 
     assert_eq!(gt, binary_dilation(&mask, Kernel3d::Full, 1));
+}
+
+#[test]
+fn test_binary_opening() {
+    let mut mask = Mask::from_elem((7, 7, 7), false);
+    mask.slice_mut(s![2..6, 2..6, 2..6]).fill(true);
+    let mut gt = Mask::from_elem(mask.dim(), false);
+    assert_eq!(gt, binary_opening(&mask.view(), Kernel3d::Star, 2));
+
+    mask.slice_mut(s![1..6, 1..6, 1..6]).fill(true);
+    gt.slice_mut(s![1..6, 1..6, 1..6]).fill(true);
+    assert_eq!(gt, binary_opening(&mask.view(), Kernel3d::Full, 2));
 }

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -1,6 +1,8 @@
 use ndarray::s;
 
-use ndarray_ndimage::{binary_dilation, binary_erosion, binary_opening, dim_minus, Kernel3d, Mask};
+use ndarray_ndimage::{
+    binary_closing, binary_dilation, binary_erosion, binary_opening, dim_minus, Kernel3d, Mask,
+};
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
 fn test_binary_erosion() {
@@ -121,7 +123,7 @@ fn test_binary_dilation_corner() {
     assert_eq!(gt, binary_dilation(&mask, Kernel3d::Full, 1));
 }
 
-#[test]
+#[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)
 fn test_binary_opening() {
     let mut mask = Mask::from_elem((7, 7, 7), false);
     mask.slice_mut(s![2..6, 2..6, 2..6]).fill(true);
@@ -131,4 +133,21 @@ fn test_binary_opening() {
     mask.slice_mut(s![1..6, 1..6, 1..6]).fill(true);
     gt.slice_mut(s![1..6, 1..6, 1..6]).fill(true);
     assert_eq!(gt, binary_opening(&mask.view(), Kernel3d::Full, 2));
+}
+
+#[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)
+fn test_binary_closing() {
+    let mut mask = Mask::from_elem((7, 7, 7), false);
+    mask[(3, 3, 3)] = true;
+    let mut gt = Mask::from_elem(mask.dim(), false);
+    gt[(3, 3, 3)] = true;
+    assert_eq!(gt, binary_closing(&mask.view(), Kernel3d::Star, 2));
+
+    mask.slice_mut(s![2..5, 2..5, 2..5]).fill(true);
+    gt.slice_mut(s![2..5, 2..5, 2..5]).fill(true);
+    assert_eq!(gt, binary_closing(&mask.view(), Kernel3d::Star, 2));
+
+    mask.slice_mut(s![1..6, 1..6, 1..6]).fill(true);
+    mask.slice_mut(s![2..5, 2..5, 2..5]).fill(false);
+    assert_eq!(gt, binary_closing(&mask.view(), Kernel3d::Star, 2));
 }

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -1,6 +1,6 @@
 use ndarray::s;
 
-use ndarray_ndimage::{binary_dilation, binary_erosion, dim_minus_1, Kernel3d, Mask};
+use ndarray_ndimage::{binary_dilation, binary_erosion, dim_minus, Kernel3d, Mask};
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
 fn test_binary_erosion() {
@@ -8,11 +8,29 @@ fn test_binary_erosion() {
 
     let mut gt = Mask::from_elem((4, 5, 6), false);
     gt.slice_mut(s![1..3, 1..4, 1..5]).fill(true);
-    assert_eq!(binary_erosion(&mask, Kernel3d::Star), gt);
+    assert_eq!(binary_erosion(&mask, Kernel3d::Star, 1), gt);
 
     mask[(0, 2, 2)] = false;
     gt[(1, 2, 2)] = false;
-    assert_eq!(binary_erosion(&mask.view(), Kernel3d::Star), gt);
+    assert_eq!(binary_erosion(&mask.view(), Kernel3d::Star, 1), gt);
+
+    let mut mask = Mask::from_elem((6, 7, 8), false);
+    mask.slice_mut(s![1..5, 1..6, 1..7]).fill(true);
+    let mut gt = Mask::from_elem((6, 7, 8), false);
+    gt.slice_mut(s![2..4, 2..5, 2..6]).fill(true);
+    assert_eq!(binary_erosion(&mask, Kernel3d::Star, 1), gt);
+
+    let mut mask = Mask::from_elem((7, 7, 7), false);
+    mask.slice_mut(s![2.., 1.., 1..]).fill(true);
+    let mut gt = Mask::from_elem((7, 7, 7), false);
+    gt.slice_mut(s![4, 3..5, 3..5]).fill(true);
+    assert_eq!(gt, binary_erosion(&mask.view(), Kernel3d::Star, 2));
+
+    let mut mask = Mask::from_elem((9, 9, 9), false);
+    mask.slice_mut(s![2.., 1.., ..]).fill(true);
+    let mut gt = Mask::from_elem((9, 9, 9), false);
+    gt.slice_mut(s![5, 4..6, 3..6]).fill(true);
+    assert_eq!(gt, binary_erosion(&mask.view(), Kernel3d::Star, 3));
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
@@ -21,14 +39,14 @@ fn test_binary_erosion_hole() {
     mask[(5, 5, 5)] = false;
 
     let mut gt = Mask::from_elem((11, 11, 11), false);
-    let (width, height, depth) = dim_minus_1(&mask);
+    let (width, height, depth) = dim_minus(&mask, 1);
     gt.slice_mut(s![1..width, 1..height, 1..depth]).fill(true);
     // Remove the star shape in the image center.
     gt.slice_mut(s![4..7, 5, 5]).fill(false);
     gt.slice_mut(s![5, 4..7, 5]).fill(false);
     gt.slice_mut(s![5, 5, 4..7]).fill(false);
 
-    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Star));
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Star, 1));
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
@@ -37,12 +55,12 @@ fn test_binary_erosion_cube_kernel() {
     mask[(5, 5, 5)] = false;
 
     let mut gt = Mask::from_elem((11, 11, 11), false);
-    let (width, height, depth) = dim_minus_1(&mask);
+    let (width, height, depth) = dim_minus(&mask, 1);
     gt.slice_mut(s![1..width, 1..height, 1..depth]).fill(true);
     // Remove the cube shape in the image center.
     gt.slice_mut(s![4..7, 4..7, 4..7]).fill(false);
 
-    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Full));
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Full, 1));
 }
 
 #[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)


### PR DESCRIPTION
Adding `iterations` was much more complex than I thought.

I tried going the SciPy way with a "coordinates" image but it was slower. I probably don't understand well what SciPy does because all `iterations > 1` are almost as fast as a single iteration. I know that they use a "coordinates" trick (only working on the modified voxels in the last iteration) but this is probably more complex. I'm unable to read the Cython coce behind so I abandoned.

Then I tried simply looping and reusing our fast version. It works but we're getting slower each time. It's like using the SciPy `brute_force` argument.

In all cases, we're faster than SciPy but we're stuck with 2 kernels and really ugly code which I'm not proud of. If we ever accept all kernel, this will have to go and we will get much slower!