### PR TITLE
Pad and Correlate optimizations

### DIFF
--- a/src/filters/gaussian.rs
+++ b/src/filters/gaussian.rs
@@ -43,9 +43,10 @@ where
     let mut output = array_like(&data, data.dim(), A::zero());
 
     for d in 0..data.ndim() {
-        // TODO This can be made to work if the ByIndices padding is more robust. It works in
-        // SciPy. One just needs to reflect the input data several times. It currently crashes in
-        // `PadMode::indices()` because of an integer underflow.
+        // TODO This can be made to work if the padding modes (`reflect`, `symmetric`, `wrap`) are
+        // more robust. One just needs to reflect the input data several times if the `weights`
+        // length is greater than the input array. It works in SciPy because they are looping on a
+        // size variable instead of running the algo only once like we do.
         let n = data.len_of(Axis(d));
         if half > n {
             panic!("Data size is too small for the inputs (sigma and truncate)");

--- a/src/filters/gaussian.rs
+++ b/src/filters/gaussian.rs
@@ -32,6 +32,9 @@ where
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
 {
+    let weights = weights(sigma, order, truncate);
+    let half = weights.len() / 2;
+
     // We need 2 buffers because
     // * We're reading neignbors so we can't read and write on the same location.
     // * The process is applied for each axis on the result of the previous process.
@@ -39,8 +42,15 @@ where
     let mut data = data.to_owned();
     let mut output = array_like(&data, data.dim(), A::zero());
 
-    let weights = weights(sigma, order, truncate);
     for d in 0..data.ndim() {
+        // TODO This can be made to work if the ByIndices padding is more robust. It works in
+        // SciPy. One just needs to reflect the input data several times. It currently crashes in
+        // `PadMode::indices()` because of an integer underflow.
+        let n = data.len_of(Axis(d));
+        if half > n {
+            panic!("Data size is too small for the inputs (sigma and truncate)");
+        }
+
         inner_correlate1d(&data, &weights, Axis(d), mode, 0, &mut output);
         if d != data.ndim() - 1 {
             std::mem::swap(&mut output, &mut data);

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -113,6 +113,8 @@ impl<T: PartialEq> PadMode<T> {
     }
 
     fn indices(&self, size: usize, pad_left: usize, pad_right: usize) -> (Vec<usize>, Vec<usize>) {
+        // If we ever refactor this block to something more robust (there a panic when pad > size),
+        // remove the TODO in gaussian.rs and the "should_panic" test in filters.rs.
         match *self {
             PadMode::Reflect => (
                 (1..=pad_left).rev().map(|i| i + pad_left).collect(),

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -232,11 +232,16 @@ pub fn pad_to<S, A, D>(
             for d in 0..data.ndim() {
                 let start = pad[d][0];
                 let end = start + data.shape()[d];
+                let real_end = output.shape()[d];
                 Zip::from(output.lanes_mut(Axis(d))).for_each(|mut lane| {
                     let left = lane[start];
                     let right = lane[end - 1];
-                    lane.slice_mut(s![..start]).fill(left);
-                    lane.slice_mut(s![end..]).fill(right);
+                    for i in 0..start {
+                        lane[i] = left;
+                    }
+                    for i in end..real_end {
+                        lane[i] = right;
+                    }
                 });
             }
         }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -198,12 +198,14 @@ pub fn pad_to<S, A, D>(
         PadAction::ByIndices => {
             for d in 0..data.ndim() {
                 let pad = pad[d];
-                let (left_indices, right_indices) = mode.indices(data.shape()[d], pad[0], pad[1]);
+                let start = pad[0];
+                let end = start + data.shape()[d];
+                let (left_indices, right_indices) = mode.indices(data.shape()[d], start, pad[1]);
                 Zip::from(output.lanes_mut(Axis(d))).for_each(|mut lane| {
                     for (i, &ii) in left_indices.iter().enumerate() {
                         lane[i] = lane[ii];
                     }
-                    for (i, &ii) in right_indices.iter().enumerate() {
+                    for (&ii, i) in right_indices.iter().zip(end..) {
                         lane[i] = lane[ii];
                     }
                 });

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -198,18 +198,14 @@ pub fn pad_to<S, A, D>(
         PadAction::ByIndices => {
             for d in 0..data.ndim() {
                 let pad = pad[d];
-                let start = pad[0];
-                let end = start + data.shape()[d];
                 let (left_indices, right_indices) = mode.indices(data.shape()[d], pad[0], pad[1]);
-                let mut buffer = Array1::zeros(output.shape()[d]);
                 Zip::from(output.lanes_mut(Axis(d))).for_each(|mut lane| {
-                    buffer.assign(&lane);
-                    Zip::from(lane.slice_mut(s![..start])).and(&left_indices).for_each(|e, &i| {
-                        *e = buffer[i];
-                    });
-                    Zip::from(lane.slice_mut(s![end..])).and(&right_indices).for_each(|e, &i| {
-                        *e = buffer[i];
-                    });
+                    for (i, &ii) in left_indices.iter().enumerate() {
+                        lane[i] = lane[ii];
+                    }
+                    for (i, &ii) in right_indices.iter().enumerate() {
+                        lane[i] = lane[ii];
+                    }
                 });
             }
         }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -78,7 +78,8 @@ impl<T: PartialEq> PadMode<T> {
             PadMode::Maximum | PadMode::Mean | PadMode::Median | PadMode::Minimum => {
                 PadAction::ByLane
             }
-            PadMode::Reflect | PadMode::Symmetric | PadMode::Wrap => PadAction::ByIndices,
+            PadMode::Reflect | PadMode::Symmetric => PadAction::ByReflecting,
+            PadMode::Wrap => PadAction::ByWrapping,
             PadMode::Edge => PadAction::BySides,
         }
     }
@@ -111,33 +112,14 @@ impl<T: PartialEq> PadMode<T> {
     fn needs_buffer(&self) -> bool {
         *self == PadMode::Median
     }
-
-    fn indices(&self, size: usize, pad_left: usize, pad_right: usize) -> (Vec<usize>, Vec<usize>) {
-        // If we ever refactor this block to something more robust (there a panic when pad > size),
-        // remove the TODO in gaussian.rs and the "should_panic" test in filters.rs.
-        match *self {
-            PadMode::Reflect => (
-                (1..=pad_left).rev().map(|i| i + pad_left).collect(),
-                (size - pad_right - 1..size - 1).rev().map(|i| i + pad_left).collect(),
-            ),
-            PadMode::Symmetric => (
-                (0..pad_left).rev().map(|i| i + pad_left).collect(),
-                (size - pad_right..size).rev().map(|i| i + pad_left).collect(),
-            ),
-            PadMode::Wrap => (
-                (size - pad_left..size).map(|i| i + pad_left).collect(),
-                (0..pad_right).map(|i| i + pad_left).collect(),
-            ),
-            _ => panic!("Only Reflect, Symmetric and Wrap have indices"),
-        }
-    }
 }
 
 #[derive(PartialEq)]
 enum PadAction {
     StopAfterCopy,
     ByLane,
-    ByIndices,
+    ByReflecting,
+    ByWrapping,
     BySides,
 }
 
@@ -187,30 +169,70 @@ pub fn pad_to<S, A, D>(
 
     // Select portion of padded array that needs to be copied from the original array.
     output
-        .view_mut()
         .slice_each_axis_mut(|ad| {
             let AxisDescription { axis, len, .. } = ad;
-            let d = axis.index();
-            Slice::from(pad[d][0]..len - pad[d][1])
+            let pad = pad[axis.index()];
+            Slice::from(pad[0]..len - pad[1])
         })
         .assign(data);
 
     match mode.action() {
         PadAction::StopAfterCopy => { /* Nothing */ }
-        PadAction::ByIndices => {
+        PadAction::ByReflecting => {
+            let edge_offset = match mode {
+                PadMode::Reflect => 1,
+                PadMode::Symmetric => 0,
+                _ => unreachable!(),
+            };
             for d in 0..data.ndim() {
                 let pad = pad[d];
-                let start = pad[0];
-                let end = start + data.shape()[d];
-                let (left_indices, right_indices) = mode.indices(data.shape()[d], start, pad[1]);
-                Zip::from(output.lanes_mut(Axis(d))).for_each(|mut lane| {
-                    for (i, &ii) in left_indices.iter().enumerate() {
-                        lane[i] = lane[ii];
+                let d = Axis(d);
+
+                let (mut left, rest) = output.view_mut().split_at(d, pad[0]);
+                left.assign(&rest.slice_each_axis(|ad| {
+                    if ad.axis == d {
+                        Slice::from(edge_offset..edge_offset + pad[0]).step_by(-1)
+                    } else {
+                        Slice::from(..)
                     }
-                    for (&ii, i) in right_indices.iter().zip(end..) {
-                        lane[i] = lane[ii];
+                }));
+
+                let idx = output.len_of(d) - pad[1];
+                let (rest, mut right) = output.view_mut().split_at(d, idx);
+                right.assign(&rest.slice_each_axis(|ad| {
+                    let AxisDescription { axis, len, .. } = ad;
+                    if axis == d {
+                        Slice::from(len - pad[1] - edge_offset..len - edge_offset).step_by(-1)
+                    } else {
+                        Slice::from(..)
                     }
-                });
+                }));
+            }
+        }
+        PadAction::ByWrapping => {
+            for d in 0..data.ndim() {
+                let pad = pad[d];
+                let d = Axis(d);
+
+                let (mut left, rest) = output.view_mut().split_at(d, pad[0]);
+                left.assign(&rest.slice_each_axis(|ad| {
+                    let AxisDescription { axis, len, .. } = ad;
+                    if axis == d {
+                        Slice::from(len - pad[0] - pad[1]..len - pad[1])
+                    } else {
+                        Slice::from(..)
+                    }
+                }));
+
+                let idx = output.len_of(d) - pad[1];
+                let (rest, mut right) = output.view_mut().split_at(d, idx);
+                right.assign(&rest.slice_each_axis(|ad| {
+                    if ad.axis == d {
+                        Slice::from(pad[0]..pad[0] + pad[1])
+                    } else {
+                        Slice::from(..)
+                    }
+                }));
             }
         }
         PadAction::ByLane => {

--- a/tests/pad.rs
+++ b/tests/pad.rs
@@ -18,6 +18,9 @@ fn simple_data_3d() -> Array3<f64> {
 #[test] // Results verified with the `pad(mode='maximum')` function from NumPy. (v1.21.4)
 fn test_pad_minmax() {
     let data = simple_data_1d();
+    assert_eq!(pad(&data, &[[1, 0]], PadMode::Minimum), arr1(&[0, 0, 1, 2, 3]));
+    assert_eq!(pad(&data, &[[0, 1]], PadMode::Minimum), arr1(&[0, 1, 2, 3, 0]));
+    assert_eq!(pad(&data, &[[1, 1]], PadMode::Minimum), arr1(&[0, 0, 1, 2, 3, 0]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Maximum), arr1(&[3, 3, 0, 1, 2, 3, 3, 3]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Minimum), arr1(&[0, 0, 0, 1, 2, 3, 0, 0]));
 
@@ -167,6 +170,8 @@ fn test_pad_median() {
 #[test] // Results verified with the `pad(mode='reflect')` function from NumPy. (v1.21.4)
 fn test_pad_reflect() {
     let data = simple_data_1d();
+    assert_eq!(pad(&data, &[[1, 0]], PadMode::Reflect), arr1(&[1, 0, 1, 2, 3]));
+    assert_eq!(pad(&data, &[[0, 1]], PadMode::Reflect), arr1(&[0, 1, 2, 3, 2]));
     assert_eq!(pad(&data, &[[1, 1]], PadMode::Reflect), arr1(&[1, 0, 1, 2, 3, 2]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Reflect), arr1(&[2, 1, 0, 1, 2, 3, 2, 1]));
 
@@ -250,6 +255,8 @@ fn test_pad_reflect() {
 #[test] // Results verified with the `pad(mode='symmetric')` function from NumPy. (v1.21.4)
 fn test_pad_symmetric() {
     let data = simple_data_1d();
+    assert_eq!(pad(&data, &[[1, 0]], PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3]));
+    assert_eq!(pad(&data, &[[0, 1]], PadMode::Symmetric), arr1(&[0, 1, 2, 3, 3]));
     assert_eq!(pad(&data, &[[1, 1]], PadMode::Symmetric), arr1(&[0, 0, 1, 2, 3, 3]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Symmetric), arr1(&[1, 0, 0, 1, 2, 3, 3, 2]));
 
@@ -333,6 +340,8 @@ fn test_pad_symmetric() {
 #[test] // Results verified with the `pad(mode='wrap')` function from NumPy. (v1.21.4)
 fn test_pad_wrap() {
     let data = simple_data_1d();
+    assert_eq!(pad(&data, &[[1, 0]], PadMode::Wrap), arr1(&[3, 0, 1, 2, 3]));
+    assert_eq!(pad(&data, &[[0, 1]], PadMode::Wrap), arr1(&[0, 1, 2, 3, 0]));
     assert_eq!(pad(&data, &[[1, 1]], PadMode::Wrap), arr1(&[3, 0, 1, 2, 3, 0]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Wrap), arr1(&[2, 3, 0, 1, 2, 3, 0, 1]));
 
@@ -416,6 +425,9 @@ fn test_pad_wrap() {
 #[test] // Results verified with the `pad(mode='median')` function from NumPy. (v1.21.4)
 fn test_pad_edge() {
     let data = simple_data_1d();
+    assert_eq!(pad(&data, &[[1, 0]], PadMode::Edge), arr1(&[0, 0, 1, 2, 3]));
+    assert_eq!(pad(&data, &[[0, 1]], PadMode::Edge), arr1(&[0, 1, 2, 3, 3]));
+    assert_eq!(pad(&data, &[[1, 1]], PadMode::Edge), arr1(&[0, 0, 1, 2, 3, 3]));
     assert_eq!(pad(&data, &[[2, 2]], PadMode::Edge), arr1(&[0, 0, 0, 1, 2, 3, 3, 3]));
 
     let data = simple_data_2d();


### PR DESCRIPTION
The only untouched methods are the ones related to morphology. Everything else is much faster.

- I can't get `pad` to be faster then NumPy's. I'm 95% convinced that it's impossible with ndarray 0.15.x. Just copying the input into the padded center region takes longer than the complete job in NumPy.
- Even so, `pad` is a lot faster than it was. Depending in the `mode`, I'm 50%-400% faster.
- Correlate is also faster. It was automatically optimized by `pad` and I made one loop faster and I used `unsafe` in the other loops. I think we're around 25% faster. And we're faster than SciPy for some inputs and args.

See #4. This MR doesn't fix the issue but we're much better now!