### PR TITLE
Ball and generic kernels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,16 @@ pub type Mask = Array3<bool>;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Kernel3d {
     /// Diamond/star kernel (center and sides).
+    ///
+    /// Equivalent to `generate_binary_structure(3, 1)`
     Star,
+    /// Ball kernel (center and sides).
+    ///
+    /// Equivalent to `generate_binary_structure(3, 2)`
+    Ball,
     /// 3x3 cube.
+    ///
+    /// Equivalent to `generate_binary_structure(3, 3)`
     Full,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,22 +30,35 @@ pub use pad::{pad, pad_to, PadMode};
 pub type Mask = Array3<bool>;
 
 /// 3D common kernels. Also called Structuring Element.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Kernel3d<'a> {
     /// Diamond/star kernel (center and sides).
     ///
-    /// Equivalent to `generate_binary_structure(3, 1)`
+    /// Equivalent to `generate_binary_structure(3, 1)`.
     Star,
     /// Ball kernel (center and sides).
     ///
-    /// Equivalent to `generate_binary_structure(3, 2)`
+    /// Equivalent to `generate_binary_structure(3, 2)`.
     Ball,
     /// 3x3x3 cube.
     ///
-    /// Equivalent to `generate_binary_structure(3, 3)`
+    /// Equivalent to `generate_binary_structure(3, 3)`.
     Full,
     /// Generic kernel of any 3D size.
+    ///
+    /// The generic kernels are incredibly slower on all morphological operations.
     Generic(ArrayView3<'a, bool>),
+}
+
+impl<'a> std::fmt::Debug for Kernel3d<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Kernel3d::Star => write!(f, "Star {:?}", self.dim()),
+            Kernel3d::Ball => write!(f, "Ball {:?}", self.dim()),
+            Kernel3d::Full => write!(f, "Full {:?}", self.dim()),
+            Kernel3d::Generic(k) => write!(f, "Generic {:?}", k.dim()),
+        }
+    }
 }
 
 impl<'a> Kernel3d<'a> {

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -52,7 +52,22 @@ fn test_binary_erosion_hole() {
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
-fn test_binary_erosion_cube_kernel() {
+fn test_binary_erosion_ball_kernel() {
+    let mut mask = Mask::from_elem((11, 11, 11), true);
+    mask[(5, 5, 5)] = false;
+
+    let mut gt = Mask::from_elem((11, 11, 11), false);
+    let (width, height, depth) = dim_minus(&mask, 1);
+    gt.slice_mut(s![1..width, 1..height, 1..depth]).fill(true);
+    // Remove the ball shape in the image center.
+    gt.slice_mut(s![4..7, 4..7, 4..7]).fill(false);
+    gt.slice_mut(s![4..7; 2, 4..7; 2, 4..7; 2]).fill(true);
+
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Ball, 1));
+}
+
+#[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
+fn test_binary_erosion_full_kernel() {
     let mut mask = Mask::from_elem((11, 11, 11), true);
     mask[(5, 5, 5)] = false;
 
@@ -98,6 +113,13 @@ fn test_binary_dilation_plain() {
     gt.slice_mut(s![2..w - 1, h - 1, 2..d - 1]).fill(true);
 
     assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Star, 1));
+
+    let mut mask = Mask::from_elem((w, h, d), false);
+    mask.slice_mut(s![4, 4, 4..]).fill(true);
+    let mut gt = Mask::from_elem((w, h, d), false);
+    gt.slice_mut(s![3..6, 3..6, 3..]).fill(true);
+    gt.slice_mut(s![3..6; 2, 3..6; 2, 3]).fill(false);
+    assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Ball, 1));
 
     let mut mask = Mask::from_elem((w, h, d), false);
     mask[(4, 4, 4)] = true;

--- a/tests/morphology.rs
+++ b/tests/morphology.rs
@@ -49,6 +49,7 @@ fn test_binary_erosion_hole() {
     gt.slice_mut(s![5, 5, 4..7]).fill(false);
 
     assert_eq!(gt, binary_erosion(&mask, Kernel3d::Star, 1));
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Generic(Kernel3d::Star.array().view()), 1));
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
@@ -64,6 +65,7 @@ fn test_binary_erosion_ball_kernel() {
     gt.slice_mut(s![4..7; 2, 4..7; 2, 4..7; 2]).fill(true);
 
     assert_eq!(gt, binary_erosion(&mask, Kernel3d::Ball, 1));
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Generic(Kernel3d::Ball.array().view()), 1));
 }
 
 #[test] // Results verified with the `binary_erosion` function from SciPy. (v1.7.0)
@@ -78,6 +80,7 @@ fn test_binary_erosion_full_kernel() {
     gt.slice_mut(s![4..7, 4..7, 4..7]).fill(false);
 
     assert_eq!(gt, binary_erosion(&mask, Kernel3d::Full, 1));
+    assert_eq!(gt, binary_erosion(&mask, Kernel3d::Generic(Kernel3d::Full.array().view()), 1));
 }
 
 #[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)
@@ -113,6 +116,7 @@ fn test_binary_dilation_plain() {
     gt.slice_mut(s![2..w - 1, h - 1, 2..d - 1]).fill(true);
 
     assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Star, 1));
+    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Generic(Kernel3d::Star.array().view()), 1));
 
     let mut mask = Mask::from_elem((w, h, d), false);
     mask.slice_mut(s![4, 4, 4..]).fill(true);
@@ -120,18 +124,21 @@ fn test_binary_dilation_plain() {
     gt.slice_mut(s![3..6, 3..6, 3..]).fill(true);
     gt.slice_mut(s![3..6; 2, 3..6; 2, 3]).fill(false);
     assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Ball, 1));
+    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Generic(Kernel3d::Ball.array().view()), 1));
 
     let mut mask = Mask::from_elem((w, h, d), false);
     mask[(4, 4, 4)] = true;
     let mut gt = Mask::from_elem((w, h, d), false);
     gt.slice_mut(s![2.., 2.., 2..]).fill(true);
     assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Full, 2));
+    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Generic(Kernel3d::Full.array().view()), 2));
 
     let mut mask = Mask::from_elem((w, h, d), false);
     mask[(4, 5, 5)] = true;
     let mut gt = Mask::from_elem((w, h, d), false);
     gt.slice_mut(s![1.., 2.., 2..]).fill(true);
     assert_eq!(gt, binary_dilation(&mask.view(), Kernel3d::Full, 3));
+    assert_eq!(gt, binary_dilation(&mask, Kernel3d::Generic(Kernel3d::Full.array().view()), 3));
 }
 
 #[test] // Results verified with the `binary_dilation` function from SciPy. (v1.7.0)


### PR DESCRIPTION
The generic kernels are incredibly slow, much more than SciPy. I'm not sure what to do about it.
- The dilation operation will be made a little faster when this [ndarray MR](https://github.com/rust-ndarray/ndarray/pull/1228) is merged because `Zip` is always faster than standard iteration.
- It's slow but it's the cleanest code around. It will be made faster with rustc and ndarray enhancements.
- I'll probably look into SciPy and ANTs `ImageMath` algorithms to find how they can be so fast.