### PR TITLE
Add structure parameter to label (and friends)

### DIFF
--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -81,12 +81,14 @@ where
     // https://github.com/scipy/scipy/blob/v0.16.1/scipy/ndimage/src/_ni_label.pyx
     // N-D: Use a loop in `is_valid` and change the `labels` indexing (might be hard in Rust)
 
-    let nb_neighbors = structure.len() / 6;
+    let nb_neighbors = structure.len() / (3 * 2);
     let kernel_data: Vec<([bool; 3], [isize; 2])> = structure
         .lanes(Axis(2))
         .into_iter()
-        .zip(0isize..nb_neighbors as isize)
-        // Filter out kernel lanes with no true elements (since that are no-ops)
+        .zip(0isize..)
+        // Only consider lanes before the center
+        .take(nb_neighbors)
+        // Filter out kernel lanes with no `true` elements (since that are no-ops)
         .filter(|(lane, _)| lane.iter().any(|x| *x))
         .map(|(lane, i)| {
             let kernel = [lane[0], lane[1], lane[2]];

--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -89,7 +89,7 @@ where
         // Filter out kernel lanes with no true elements (since that are no-ops)
         .filter(|(lane, _)| lane.iter().any(|x| *x))
         .map(|(lane, i)| {
-            let kernel: [bool; 3] = lane.iter().map(|x| *x).collect::<Vec<_>>().try_into().unwrap();
+            let kernel = [lane[0], lane[1], lane[2]];
             // Convert i into coordinates
             let y = i / 3;
             let x = i - y * 3;

--- a/tests/measurements.rs
+++ b/tests/measurements.rs
@@ -1,13 +1,14 @@
 use ndarray::{arr3, s, Array3};
 
 use ndarray_ndimage::{
-    label, label_histogram, largest_connected_components, most_frequent_label, Mask,
+    label, label_histogram, largest_connected_components, most_frequent_label, Kernel3d, Mask,
 };
 
 #[test] // Results verified with the `label` function from SciPy. (v1.7.0)
 fn test_label_0() {
+    let star = Kernel3d::Star.generate();
     let data = Array3::zeros((3, 3, 3));
-    let (labels, nb_features) = label(&data.mapv(|v| v > 0));
+    let (labels, nb_features) = label(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, data);
     assert_eq!(nb_features, 0);
     assert_eq!(label_histogram(&labels, nb_features), vec![27]);
@@ -16,12 +17,13 @@ fn test_label_0() {
 
 #[test] // Results verified with the `label` function from SciPy. (v1.7.0)
 fn test_label_2() {
+    let star = Kernel3d::Star.generate();
     let data = arr3(&[
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
     ]);
-    let (labels, nb_features) = label(&data.mapv(|v| v > 0));
+    let (labels, nb_features) = label(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, data);
     assert_eq!(nb_features, 1);
     assert_eq!(label_histogram(&labels, nb_features), vec![18, 9]);
@@ -30,6 +32,7 @@ fn test_label_2() {
 
 #[test] // Results verified with the `label` function from SciPy. (v1.7.0)
 fn test_label_3() {
+    let star = Kernel3d::Star.generate();
     let data = arr3(&[
         [[2, 2, 2], [2, 2, 2], [0, 0, 0]],
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
@@ -40,7 +43,7 @@ fn test_label_3() {
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
     ]);
-    let (labels, nb_features) = label(&data.mapv(|v| v > 0));
+    let (labels, nb_features) = label(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 2);
     assert_eq!(label_histogram(&labels, nb_features), vec![12, 6, 9]);
@@ -49,6 +52,7 @@ fn test_label_3() {
 
 #[test] // Results verified with the `label` function from SciPy. (v1.7.0)
 fn test_label_4() {
+    let star = Kernel3d::Star.generate();
     let data = arr3(&[
         [[0.9, 0.9, 0.9, 0.9], [0.0, 0.7, 0.8, 0.7], [0.0, 0.0, 0.0, 0.0]],
         [[0.9, 0.9, 0.9, 0.8], [0.9, 0.8, 0.8, 0.8], [0.0, 0.0, 0.0, 0.7]],
@@ -87,7 +91,7 @@ fn test_label_4() {
         [[0, 0, 2, 2], [0, 0, 2, 0], [0, 0, 0, 0]],
         [[3, 3, 0, 0], [3, 0, 0, 0], [0, 0, 0, 0]],
     ]);
-    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7));
+    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7), &star);
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 3);
     assert_eq!(label_histogram(&gt, nb_features), vec![71, 127, 3, 3]);
@@ -96,6 +100,7 @@ fn test_label_4() {
 
 #[test] // Results verified with the `label` function from SciPy. (v1.7.0)
 fn test_label_5() {
+    let star = Kernel3d::Star.generate();
     let data = arr3(&[
         [
             [0.9, 0.8, 0.7, 0.0, 0.7],
@@ -172,7 +177,7 @@ fn test_label_5() {
             [3, 0, 0, 0, 0],
         ],
     ]);
-    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7).view());
+    let (labels, nb_features) = label(&data.mapv(|v| v >= 0.7).view(), &star.view());
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 3);
     assert_eq!(label_histogram(&gt, nb_features), vec![113, 33, 2, 2]);
@@ -181,6 +186,7 @@ fn test_label_5() {
 
 #[test] // Results verified manually.
 fn test_largest_connected_components() {
+    let star = Kernel3d::Star.generate();
     let mut mask = Mask::from_elem((10, 10, 10), false);
     mask.slice_mut(s![2..4, 2..4, 2..4]).fill(true);
     mask.slice_mut(s![6..8, 6..8, 6..8]).fill(true);
@@ -189,7 +195,7 @@ fn test_largest_connected_components() {
     let mut gt = Mask::from_elem(mask.dim(), false);
     gt.slice_mut(s![6..8, 6..8, 6..8]).fill(true);
     gt[(7, 7, 8)] = true;
-    assert_eq!(largest_connected_components(&mask).unwrap(), gt);
+    assert_eq!(largest_connected_components(&mask, &star).unwrap(), gt);
 
     mask[(3, 3, 4)] = true;
     mask[(3, 4, 4)] = true;
@@ -197,5 +203,80 @@ fn test_largest_connected_components() {
     gt.slice_mut(s![2..4, 2..4, 2..4]).fill(true);
     gt[(3, 3, 4)] = true;
     gt[(3, 4, 4)] = true;
-    assert_eq!(largest_connected_components(&mask.view()).unwrap(), gt);
+    assert_eq!(largest_connected_components(&mask.view(), &star.view()).unwrap(), gt);
+}
+
+#[test] // Results verified with the `label` function from SciPy. (v1.9.1)
+fn test_label_different_kernels() {
+    let data = arr3(&[
+        [[0, 1, 0, 0], [1, 1, 0, 0], [0, 0, 0, 1]],
+        [[0, 0, 0, 0], [1, 0, 1, 0], [0, 0, 0, 0]],
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0]],
+    ]);
+    let star_result = arr3(&[
+        [[0, 1, 0, 0], [1, 1, 0, 0], [0, 0, 0, 2]],
+        [[0, 0, 0, 0], [1, 0, 3, 0], [0, 0, 0, 0]],
+        [[4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 6, 0], [0, 0, 6, 0]],
+    ]);
+    let ball_result = arr3(&[
+        [[0, 1, 0, 0], [1, 1, 0, 0], [0, 0, 0, 2]],
+        [[0, 0, 0, 0], [1, 0, 1, 0], [0, 0, 0, 0]],
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0]],
+    ]);
+    let full_result = arr3(&[
+        [[0, 1, 0, 0], [1, 1, 0, 0], [0, 0, 0, 1]],
+        [[0, 0, 0, 0], [1, 0, 1, 0], [0, 0, 0, 0]],
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0]],
+    ]);
+    let odd1_kernel = arr3(&[
+        [[true, false, true], [true, false, false], [false, true, true]],
+        [[false, true, false], [false, true, false], [false, true, false]],
+        [[true, true, false], [false, false, true], [true, false, true]],
+    ]);
+    let odd1_result = arr3(&[
+        [[0, 1, 0, 0], [2, 1, 0, 0], [0, 0, 0, 1]],
+        [[0, 0, 0, 0], [1, 0, 1, 0], [0, 0, 0, 0]],
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0]],
+    ]);
+    let odd2_kernel = arr3(&[
+        [[true, false, true], [false, false, false], [true, false, true]],
+        [[false, false, false], [false, true, false], [false, false, false]],
+        [[true, false, true], [false, false, false], [true, false, true]],
+    ]);
+    let odd2_result = arr3(&[
+        [[0, 1, 0, 0], [2, 3, 0, 0], [0, 0, 0, 1]],
+        [[0, 0, 0, 0], [1, 0, 1, 0], [0, 0, 0, 0]],
+        [[4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 0, 0]],
+        [[0, 0, 0, 0], [0, 0, 6, 0], [0, 0, 5, 0]],
+    ]);
+    {
+        let (labels, nb_features) = label(&data.mapv(|v| v > 0), &Kernel3d::Star.generate());
+        assert_eq!(labels, star_result);
+        assert_eq!(nb_features, 6);
+    }
+    {
+        let (labels, nb_features) = label(&data.mapv(|v| v > 0), &Kernel3d::Ball.generate());
+        assert_eq!(labels, ball_result);
+        assert_eq!(nb_features, 2);
+    }
+    {
+        let (labels, nb_features) = label(&data.mapv(|v| v > 0), &Kernel3d::Full.generate());
+        assert_eq!(labels, full_result);
+        assert_eq!(nb_features, 1);
+    }
+    {
+        let (labels, nb_features) = label(&data.mapv(|v| v > 0), &odd1_kernel);
+        assert_eq!(labels, odd1_result);
+        assert_eq!(nb_features, 2);
+    }
+    {
+        let (labels, nb_features) = label(&data.mapv(|v| v > 0), &odd2_kernel);
+        assert_eq!(labels, odd2_result);
+        assert_eq!(nb_features, 6);
+    }
 }


### PR DESCRIPTION
Extend `label` and `largest_connected_components` to support any (valid) 3D kernel, based on what scipy does. From my timing, this results in no observable change in execution time for the star kernel (and eyeballing it, the only lost optimisation I can see is a possible unrolling the `kernel_data` loop). However, this is a more disruptive API change, so I could adjust things so that `label` keeps it's interface and I add another `label_with_kernel` function if you want.

Tests run with rustc 1.72.0 and ndarray 0.15.6.