### PR TITLE
Use new types from ndarray 0.17

### DIFF
--- a/src/filters/con_corr.rs
+++ b/src/filters/con_corr.rs
@@ -1,5 +1,5 @@
 use ndarray::{
-    s, Array, Array1, ArrayBase, Axis, Data, Dimension, Ix1, ScalarOperand, ShapeArg, Zip,
+    s, Array, Array1, ArrayRef, ArrayRef1, Axis, Dimension, ScalarOperand, ShapeArg, Zip
 };
 use num_traits::{FromPrimitive, Num, Signed};
 
@@ -20,15 +20,14 @@ use crate::{array_like, pad, pad_to, BorderMode};
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///    centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///    negative ones to the right.
-pub fn convolve1d<S, A, D>(
-    data: &ArrayBase<S, D>,
-    weights: &ArrayBase<S, Ix1>,
+pub fn convolve1d<A, D>(
+    data: &ArrayRef<A, D>,
+    weights: &ArrayRef1<A>,
     axis: Axis,
     mode: BorderMode<A>,
     mut origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + ScalarOperand + FromPrimitive + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -64,15 +63,14 @@ where
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///    centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///    negative ones to the right.
-pub fn correlate1d<S, A, D>(
-    data: &ArrayBase<S, D>,
-    weights: &ArrayBase<S, Ix1>,
+pub fn correlate1d<A, D>(
+    data: &ArrayRef<A, D>,
+    weights: &ArrayRef1<A>,
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + ScalarOperand + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -96,15 +94,14 @@ where
     output
 }
 
-pub(crate) fn inner_correlate1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub(crate) fn inner_correlate1d<A, D>(
+    data: &ArrayRef<A, D>,
     weights: &[A],
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -179,14 +176,13 @@ pub(crate) fn inner_correlate1d<S, A, D>(
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///    centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///    negative ones to the right.
-pub fn convolve<S, A, D>(
-    data: &ArrayBase<S, D>,
-    weights: &ArrayBase<S, D>,
+pub fn convolve<A, D>(
+    data: &ArrayRef<A, D>,
+    weights: &ArrayRef<A, D>,
     mode: BorderMode<A>,
     mut origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd,
     D: Dimension,
 {
@@ -223,14 +219,13 @@ where
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///    centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///    negative ones to the right.
-pub fn correlate<S, A, D>(
-    data: &ArrayBase<S, D>,
-    weights: &ArrayBase<S, D>,
+pub fn correlate<A, D>(
+    data: &ArrayRef<A, D>,
+    weights: &ArrayRef<A, D>,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd,
     D: Dimension,
 {
@@ -238,14 +233,13 @@ where
     _correlate(data, weights.to_owned(), mode, origin)
 }
 
-fn _correlate<S, A, D>(
-    data: &ArrayBase<S, D>,
+fn _correlate<A, D>(
+    data: &ArrayRef<A, D>,
     weights: Array<A, D>,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd,
     D: Dimension,
 {
@@ -278,9 +272,8 @@ where
 /// * `axis` - The axis of input along which to calculate.
 /// * `mode` - Method that will be used to select the padded values. See the
 ///   [`CorrelateMode`](crate::CorrelateMode) enum for more information.
-pub fn prewitt<S, A, D>(data: &ArrayBase<S, D>, axis: Axis, mode: BorderMode<A>) -> Array<A, D>
+pub fn prewitt<A, D>(data: &ArrayRef<A, D>, axis: Axis, mode: BorderMode<A>) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Signed + ScalarOperand + FromPrimitive + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -295,9 +288,8 @@ where
 /// * `axis` - The axis of input along which to calculate.
 /// * `mode` - Method that will be used to select the padded values. See the
 ///   [`CorrelateMode`](crate::CorrelateMode) enum for more information.
-pub fn sobel<S, A, D>(data: &ArrayBase<S, D>, axis: Axis, mode: BorderMode<A>) -> Array<A, D>
+pub fn sobel<A, D>(data: &ArrayRef<A, D>, axis: Axis, mode: BorderMode<A>) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Signed + ScalarOperand + FromPrimitive + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -306,14 +298,13 @@ where
     inner_prewitt_sobel(data, axis, mode, &second_weights)
 }
 
-fn inner_prewitt_sobel<S, A, D>(
-    data: &ArrayBase<S, D>,
+fn inner_prewitt_sobel<A, D>(
+    data: &ArrayRef<A, D>,
     axis: Axis,
     mode: BorderMode<A>,
     second_weights: &[A],
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Signed + ScalarOperand + FromPrimitive + PartialOrd,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,

--- a/src/filters/gaussian.rs
+++ b/src/filters/gaussian.rs
@@ -1,4 +1,4 @@
-use ndarray::{s, Array, Array1, Array2, ArrayBase, Axis, Data, Dimension, Zip};
+use ndarray::{s, Array, Array1, Array2, ArrayRef, Axis, Dimension, Zip};
 use num_traits::{Float, FromPrimitive};
 
 use crate::{array_like, BorderMode};
@@ -19,15 +19,14 @@ use super::{con_corr::inner_correlate1d, symmetry::SymmetryStateCheck};
 /// * `truncate` - Truncate the filter at this many standard deviations.
 ///
 /// **Panics** if one of the axis' lengths is lower than `truncate * sigma + 0.5`.
-pub fn gaussian_filter<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn gaussian_filter<A, D>(
+    data: &ArrayRef<A, D>,
     sigma: A,
     order: usize,
     mode: BorderMode<A>,
     truncate: usize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Float + FromPrimitive + 'static,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,
@@ -73,8 +72,8 @@ where
 /// * `truncate` - Truncate the filter at this many standard deviations.
 ///
 /// **Panics** if the axis length is lower than `truncate * sigma + 0.5`.
-pub fn gaussian_filter1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn gaussian_filter1d<A, D>(
+    data: &ArrayRef<A, D>,
     sigma: A,
     axis: Axis,
     order: usize,
@@ -82,7 +81,6 @@ pub fn gaussian_filter1d<S, A, D>(
     truncate: usize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Float + FromPrimitive + 'static,
     for<'a> &'a [A]: SymmetryStateCheck,
     D: Dimension,

--- a/src/filters/median.rs
+++ b/src/filters/median.rs
@@ -1,4 +1,4 @@
-use ndarray::{s, ArrayBase, Data, Ix3, Zip};
+use ndarray::{s, ArrayRef3, Zip};
 
 use crate::{array_like, dim_minus, Mask};
 
@@ -6,9 +6,7 @@ use crate::{array_like, dim_minus, Mask};
 ///
 /// A 3x3 structuring element (`Kernel3d::Full`) is used except on the borders, where a smaller
 /// structuring element is used.
-pub fn median_filter<S>(mask: &ArrayBase<S, Ix3>) -> Mask
-where
-    S: Data<Elem = bool>,
+pub fn median_filter(mask: &ArrayRef3<bool>) -> Mask
 {
     let range = |i, max| {
         if i == 0 {

--- a/src/filters/min_max.rs
+++ b/src/filters/min_max.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use ndarray::{Array, Array1, ArrayBase, Axis, Data, Dimension, ScalarOperand, Zip};
+use ndarray::{Array, Array1, ArrayRef, Axis, Dimension, ScalarOperand, Zip};
 use num_traits::{FromPrimitive, Num};
 
 use crate::{array_like, filters::origin_check, pad_to, BorderMode};
@@ -17,15 +17,14 @@ use crate::{array_like, filters::origin_check, pad_to, BorderMode};
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///   centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///   negative ones to the right.
-pub fn maximum_filter1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn maximum_filter1d<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -43,14 +42,13 @@ where
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///   centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///   negative ones to the right.
-pub fn maximum_filter<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn maximum_filter<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -73,15 +71,14 @@ where
 /// Calculate a 1-D maximum filter along the given axis.
 ///
 /// See `maximum_filter1d`.
-pub fn maximum_filter1d_to<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn maximum_filter1d_to<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -102,15 +99,14 @@ pub fn maximum_filter1d_to<S, A, D>(
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///   centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///   negative ones to the right.
-pub fn minimum_filter1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn minimum_filter1d<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -128,14 +124,13 @@ where
 /// * `origin` - Controls the placement of the filter on the input array’s pixels. A value of 0
 ///   centers the filter over the pixel, with positive values shifting the filter to the left, and
 ///   negative ones to the right.
-pub fn minimum_filter<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn minimum_filter<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     mode: BorderMode<A>,
     origin: isize,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -158,15 +153,14 @@ where
 /// Calculate a 1-D minimum filter along the given axis.
 ///
 /// See `minimum_filter1d`.
-pub fn minimum_filter1d_to<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn minimum_filter1d_to<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
     origin: isize,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
 {
@@ -176,8 +170,8 @@ pub fn minimum_filter1d_to<S, A, D>(
 }
 
 /// MINLIST algorithm from Richard Harter
-fn min_or_max_filter<S, A, D, F1, F2>(
-    data: &ArrayBase<S, D>,
+fn min_or_max_filter<A, D, F1, F2>(
+    data: &ArrayRef<A, D>,
     filter_size: usize,
     axis: Axis,
     mode: BorderMode<A>,
@@ -186,7 +180,6 @@ fn min_or_max_filter<S, A, D, F1, F2>(
     f2: F2,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + Num + PartialOrd + ScalarOperand + FromPrimitive,
     D: Dimension,
     F1: Fn(A, A) -> bool,

--- a/src/filters/uniform.rs
+++ b/src/filters/uniform.rs
@@ -1,4 +1,4 @@
-use ndarray::{s, Array, Array1, ArrayBase, Axis, Data, Dimension, Zip};
+use ndarray::{s, Array, Array1, ArrayRef, Axis, Dimension, Zip};
 use num_traits::{FromPrimitive, Num};
 
 use crate::{array_like, pad_to, BorderMode};
@@ -13,13 +13,12 @@ use crate::{array_like, pad_to, BorderMode};
 ///   [`BorderMode`](crate::BorderMode) enum for more information.
 ///
 /// **Panics** if `size` is zero, or one of the axis' lengths is lower than `size`.
-pub fn uniform_filter<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn uniform_filter<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     mode: BorderMode<A>,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd + 'static,
     D: Dimension,
 {
@@ -59,30 +58,28 @@ where
 ///   [`BorderMode`](crate::BorderMode) enum for more information.
 ///
 /// **Panics** if `size` is zero, or the axis length is lower than `size`.
-pub fn uniform_filter1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn uniform_filter1d<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
 ) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd + 'static,
     D: Dimension,
 {
-    let mut output = array_like(&data, data.dim(), A::zero());
+    let mut output = array_like(data, data.dim(), A::zero());
     inner_uniform1d(data, size, axis, mode, &mut output);
     output
 }
 
-pub(crate) fn inner_uniform1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub(crate) fn inner_uniform1d<A, D>(
+    data: &ArrayRef<A, D>,
     size: usize,
     axis: Axis,
     mode: BorderMode<A>,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd,
     D: Dimension,
 {

--- a/src/interpolation/spline_filter.rs
+++ b/src/interpolation/spline_filter.rs
@@ -1,4 +1,4 @@
-use ndarray::{arr1, s, Array, Array1, ArrayBase, ArrayViewMut1, Axis, Data, Dimension};
+use ndarray::{arr1, s, Array, Array1, ArrayRef, ArrayViewMut1, Axis, Dimension};
 use num_traits::ToPrimitive;
 
 use crate::BorderMode;
@@ -13,13 +13,12 @@ use crate::BorderMode;
 /// * `mode` - The mode parameter determines how the input array is extended beyond its boundaries.
 ///
 /// **Panics** if `order` isn't in the range \[2, 5\].
-pub fn spline_filter<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn spline_filter<A, D>(
+    data: &ArrayRef<A, D>,
     order: usize,
     mode: BorderMode<A>,
 ) -> Array<f64, D>
 where
-    S: Data<Elem = A>,
     A: Copy + ToPrimitive,
     D: Dimension,
 {
@@ -47,14 +46,13 @@ where
 /// * `axis` - The axis along which the spline filter is applied.
 ///
 /// **Panics** if `order` isn't in the range \[0, 5\].
-pub fn spline_filter1d<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn spline_filter1d<A, D>(
+    data: &ArrayRef<A, D>,
     order: usize,
     mode: BorderMode<A>,
     axis: Axis,
 ) -> Array<f64, D>
 where
-    S: Data<Elem = A>,
     A: Copy + ToPrimitive,
     D: Dimension,
 {

--- a/src/interpolation/zoom_shift.rs
+++ b/src/interpolation/zoom_shift.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Sub};
 
-use ndarray::{s, Array, Array2, ArrayBase, ArrayViewMut1, Data, Ix3, Zip};
+use ndarray::{s, Array2, Array3, ArrayRef3, ArrayViewMut1, Zip};
 use num_traits::{FromPrimitive, Num, ToPrimitive};
 
 use crate::{array_like, pad, round_ties_even, spline_filter, BorderMode, PadMode};
@@ -18,15 +18,14 @@ use crate::{array_like, pad, round_ties_even, spline_filter, BorderMode, PadMode
 ///   interpolation. The default is `true`, which will create a temporary `f64` array of filtered
 ///   values if `order > 1`. If setting this to `false`, the output will be slightly blurred if
 ///   `order > 1`, unless the input is prefiltered.
-pub fn shift<S, A>(
-    data: &ArrayBase<S, Ix3>,
+pub fn shift<A>(
+    data: &ArrayRef3<A>,
     shift: [f64; 3],
     order: usize,
     mode: BorderMode<A>,
     prefilter: bool,
-) -> Array<A, Ix3>
+) -> Array3<A>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd + ToPrimitive,
 {
     let dim = [data.dim().0, data.dim().1, data.dim().2];
@@ -46,15 +45,14 @@ where
 ///   interpolation. The default is `true`, which will create a temporary `f64` array of filtered
 ///   values if `order > 1`. If setting this to `false`, the output will be slightly blurred if
 ///   `order > 1`, unless the input is prefiltered.
-pub fn zoom<S, A>(
-    data: &ArrayBase<S, Ix3>,
+pub fn zoom<A>(
+    data: &ArrayRef3<A>,
     zoom: [f64; 3],
     order: usize,
     mode: BorderMode<A>,
     prefilter: bool,
-) -> Array<A, Ix3>
+) -> Array3<A>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd + ToPrimitive,
 {
     let mut o_dim = data.raw_dim();
@@ -78,17 +76,16 @@ where
     run_zoom_shift(data, o_dim, zoom, [0.0, 0.0, 0.0], order, mode, prefilter)
 }
 
-fn run_zoom_shift<S, A>(
-    data: &ArrayBase<S, Ix3>,
+fn run_zoom_shift<A>(
+    data: &ArrayRef3<A>,
     odim: [usize; 3],
     zooms: [f64; 3],
     shifts: [f64; 3],
     order: usize,
     mode: BorderMode<A>,
     prefilter: bool,
-) -> Array<A, Ix3>
+) -> Array3<A>
 where
-    S: Data<Elem = A>,
     A: Copy + Num + FromPrimitive + PartialOrd + ToPrimitive,
 {
     let idim = [data.dim().0, data.dim().1, data.dim().2];
@@ -232,9 +229,8 @@ impl ZoomShiftReslicer {
     }
 
     /// Spline interpolation with up-to 8 neighbors of a point.
-    pub fn interpolate<A, S>(&self, data: &ArrayBase<S, Ix3>, start: (usize, usize, usize)) -> f64
+    pub fn interpolate<A>(&self, data: &ArrayRef3<A>, start: (usize, usize, usize)) -> f64
     where
-        S: Data<Elem = A>,
         A: ToPrimitive + Add<Output = A> + Sub<Output = A> + Copy,
     {
         if self.zeros[0][start.0] || self.zeros[1][start.1] || self.zeros[2][start.2] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! The `ndarray-image` crate provides multidimensional image processing for `ArrayBase`,
 //! the *n*-dimensional array data structure provided by [`ndarray`].
 
-use ndarray::{arr3, Array, Array3, ArrayBase, Data, Dimension, Ix3, ShapeBuilder};
+use ndarray::{arr3, Array, Array3, ArrayRef, ArrayRef3, Dimension, ShapeBuilder};
 
 mod filters;
 mod interpolation;
@@ -68,9 +68,8 @@ impl Kernel3d {
 
 /// Utility function that returns a new *n*-dimensional array of dimension `shape` with the same
 /// datatype and memory order as the input `arr`.
-pub fn array_like<S, A, D, Sh>(arr: &ArrayBase<S, D>, shape: Sh, elem: A) -> Array<A, D>
+pub fn array_like<A, D, Sh>(arr: &ArrayRef<A, D>, shape: Sh, elem: A) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Clone,
     D: Dimension,
     Sh: ShapeBuilder<Dim = D>,
@@ -84,9 +83,8 @@ where
 }
 
 /// Utilitary function that returns the mask dimension minus 1 on all dimensions.
-pub fn dim_minus<S, A>(mask: &ArrayBase<S, Ix3>, n: usize) -> (usize, usize, usize)
+pub fn dim_minus<A>(mask: &ArrayRef3<A>, n: usize) -> (usize, usize, usize)
 where
-    S: Data<Elem = A>,
     A: Clone,
 {
     let (width, height, depth) = mask.dim();

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -1,6 +1,6 @@
 mod offsets;
 
-use ndarray::{Array3, ArrayBase, ArrayView3, ArrayViewMut3, Data, Ix3};
+use ndarray::{Array3, ArrayRef3, ArrayView3, ArrayViewMut3};
 
 use crate::Mask;
 use offsets::Offsets;
@@ -11,14 +11,11 @@ use offsets::Offsets;
 /// * `kernel` - Structuring element used for the erosion. Must be of odd length. The center must
 ///   be `true`.
 /// * `iterations` - The erosion is repeated iterations times.
-pub fn binary_erosion<SM, SK>(
-    mask: &ArrayBase<SM, Ix3>,
-    kernel: &ArrayBase<SK, Ix3>,
+pub fn binary_erosion(
+    mask: &ArrayRef3<bool>,
+    kernel: &ArrayRef3<bool>,
     iterations: usize,
 ) -> Mask
-where
-    SM: Data<Elem = bool>,
-    SK: Data<Elem = bool>,
 {
     mask.as_slice_memory_order()
         .expect("Morphological operations can only be called on arrays with contiguous memory.");
@@ -48,14 +45,11 @@ where
 /// * `kernel` - Structuring element used for the erosion. Must be of odd length. The center must
 ///   be `true`.
 /// * `iterations` - The dilation is repeated iterations times.
-pub fn binary_dilation<SM, SK>(
-    mask: &ArrayBase<SM, Ix3>,
-    kernel: &ArrayBase<SK, Ix3>,
+pub fn binary_dilation(
+    mask: &ArrayRef3<bool>,
+    kernel: &ArrayRef3<bool>,
     iterations: usize,
 ) -> Mask
-where
-    SM: Data<Elem = bool>,
-    SK: Data<Elem = bool>,
 {
     mask.as_slice_memory_order()
         .expect("Morphological operations can only be called on arrays with contiguous memory.");
@@ -92,14 +86,11 @@ where
 /// * `kernel` - Structuring element used for the opening.
 /// * `iterations` - The erosion step of the opening, then the dilation step are each repeated
 ///   iterations times.
-pub fn binary_opening<SM, SK>(
-    mask: &ArrayBase<SM, Ix3>,
-    kernel: &ArrayBase<SK, Ix3>,
+pub fn binary_opening(
+    mask: &ArrayRef3<bool>,
+    kernel: &ArrayRef3<bool>,
     iterations: usize,
 ) -> Mask
-where
-    SM: Data<Elem = bool>,
-    SK: Data<Elem = bool>,
 {
     let eroded = binary_erosion(mask, kernel, iterations);
     binary_dilation(&eroded, kernel, iterations)
@@ -118,14 +109,11 @@ where
 /// * `kernel` - Structuring element used for the closing.
 /// * `iterations` - The dilation step of the closing, then the erosion step are each repeated
 ///   iterations times.
-pub fn binary_closing<SM, SK>(
-    mask: &ArrayBase<SM, Ix3>,
-    kernel: &ArrayBase<SK, Ix3>,
+pub fn binary_closing(
+    mask: &ArrayRef3<bool>,
+    kernel: &ArrayRef3<bool>,
     iterations: usize,
 ) -> Mask
-where
-    SM: Data<Elem = bool>,
-    SK: Data<Elem = bool>,
 {
     let dilated = binary_dilation(mask, kernel, iterations);
     binary_erosion(&dilated, kernel, iterations)

--- a/src/morphology/offsets.rs
+++ b/src/morphology/offsets.rs
@@ -1,4 +1,4 @@
-use ndarray::{ArrayBase, ArrayView3, Data, Ix3};
+use ndarray::{ArrayRef3, ArrayView3};
 
 pub struct Offsets {
     mask_strides: Vec<isize>,
@@ -17,9 +17,7 @@ pub struct Offsets {
 }
 
 impl Offsets {
-    pub fn new<S>(mask: &ArrayBase<S, Ix3>, kernel: ArrayView3<bool>, is_dilate: bool) -> Offsets
-    where
-        S: Data<Elem = bool>,
+    pub fn new<A>(mask: &ArrayRef3<A>, kernel: ArrayView3<bool>, is_dilate: bool) -> Offsets
     {
         let mask_shape = mask.shape();
         let mask_strides = mask.strides().to_vec();

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use ndarray::{
-    s, Array, Array1, ArrayBase, ArrayView1, Axis, AxisDescription, Data, Dimension, Slice, Zip,
+    s, Array, Array1, ArrayRef, ArrayView1, Axis, AxisDescription, Dimension, Slice, Zip
 };
 use ndarray_stats::QuantileExt;
 use num_traits::{FromPrimitive, Num, Zero};
@@ -129,9 +129,8 @@ enum PadAction {
 /// * `pad` - Number of values padded to the edges of each axis.
 /// * `mode` - Method that will be used to select the padded values. See the
 ///   [`PadMode`](crate::PadMode) enum for more information.
-pub fn pad<S, A, D>(data: &ArrayBase<S, D>, pad: &[[usize; 2]], mode: PadMode<A>) -> Array<A, D>
+pub fn pad<A, D>(data: &ArrayRef<A, D>, pad: &[[usize; 2]], mode: PadMode<A>) -> Array<A, D>
 where
-    S: Data<Elem = A>,
     A: Copy + FromPrimitive + Num + PartialOrd,
     D: Dimension,
 {
@@ -155,13 +154,12 @@ where
 /// * `mode` - Method that will be used to select the padded values. See the
 ///   [`PadMode`](crate::PadMode) enum for more information.
 /// * `output` - An already allocated N-D array used to write the results.
-pub fn pad_to<S, A, D>(
-    data: &ArrayBase<S, D>,
+pub fn pad_to<A, D>(
+    data: &ArrayRef<A, D>,
     pad: &[[usize; 2]],
     mode: PadMode<A>,
     output: &mut Array<A, D>,
 ) where
-    S: Data<Elem = A>,
     A: Copy + FromPrimitive + Num + PartialOrd,
     D: Dimension,
 {

--- a/tests/measurements.rs
+++ b/tests/measurements.rs
@@ -8,7 +8,7 @@ use ndarray_ndimage::{
 fn test_label_0() {
     let star = Kernel3d::Star.generate();
     let data = Array3::zeros((3, 3, 3));
-    let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v > 0), &star);
+    let (labels, nb_features) = label::<u16>(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, data);
     assert_eq!(nb_features, 0);
     assert_eq!(label_histogram(&labels, nb_features), vec![27]);
@@ -23,7 +23,7 @@ fn test_label_2() {
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
     ]);
-    let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v > 0), &star);
+    let (labels, nb_features) = label::<u16>(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, data);
     assert_eq!(nb_features, 1);
     assert_eq!(label_histogram(&labels, nb_features), vec![18, 9]);
@@ -43,7 +43,7 @@ fn test_label_3() {
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
     ]);
-    let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v > 0), &star);
+    let (labels, nb_features) = label::<u16>(&data.mapv(|v| v > 0), &star);
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 2);
     assert_eq!(label_histogram(&labels, nb_features), vec![12, 6, 9]);
@@ -91,7 +91,7 @@ fn test_label_4() {
         [[0, 0, 2, 2], [0, 0, 2, 0], [0, 0, 0, 0]],
         [[3, 3, 0, 0], [3, 0, 0, 0], [0, 0, 0, 0]],
     ]);
-    let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v >= 0.7), &star);
+    let (labels, nb_features) = label::<u16>(&data.mapv(|v| v >= 0.7), &star);
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 3);
     assert_eq!(label_histogram(&gt, nb_features), vec![71, 127, 3, 3]);
@@ -177,7 +177,7 @@ fn test_label_5() {
             [3, 0, 0, 0, 0],
         ],
     ]);
-    let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v >= 0.7).view(), &star.view());
+    let (labels, nb_features) = label::<u16>(&data.mapv(|v| v >= 0.7).view(), &star.view());
     assert_eq!(labels, gt);
     assert_eq!(nb_features, 3);
     assert_eq!(label_histogram(&gt, nb_features), vec![113, 33, 2, 2]);
@@ -256,29 +256,29 @@ fn test_label_different_kernels() {
     ]);
     {
         let (labels, nb_features) =
-            label::<_, u16>(&data.mapv(|v| v > 0), &Kernel3d::Star.generate());
+            label::<u16>(&data.mapv(|v| v > 0), &Kernel3d::Star.generate());
         assert_eq!(labels, star_result);
         assert_eq!(nb_features, 6);
     }
     {
         let (labels, nb_features) =
-            label::<_, u16>(&data.mapv(|v| v > 0), &Kernel3d::Ball.generate());
+            label::<u16>(&data.mapv(|v| v > 0), &Kernel3d::Ball.generate());
         assert_eq!(labels, ball_result);
         assert_eq!(nb_features, 2);
     }
     {
         let (labels, nb_features) =
-            label::<_, u16>(&data.mapv(|v| v > 0), &Kernel3d::Full.generate());
+            label::<u16>(&data.mapv(|v| v > 0), &Kernel3d::Full.generate());
         assert_eq!(labels, full_result);
         assert_eq!(nb_features, 1);
     }
     {
-        let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v > 0), &odd1_kernel);
+        let (labels, nb_features) = label::<u16>(&data.mapv(|v| v > 0), &odd1_kernel);
         assert_eq!(labels, odd1_result);
         assert_eq!(nb_features, 2);
     }
     {
-        let (labels, nb_features) = label::<_, u16>(&data.mapv(|v| v > 0), &odd2_kernel);
+        let (labels, nb_features) = label::<u16>(&data.mapv(|v| v > 0), &odd2_kernel);
         assert_eq!(labels, odd2_result);
         assert_eq!(nb_features, 6);
     }
@@ -299,7 +299,7 @@ fn test_label_u8() {
         [[0, 0, 0, 0], [0, 0, 6, 0], [0, 0, 6, 0]],
     ]);
 
-    let (labels, nb_features) = label::<_, u8>(&data.mapv(|v| v > 0), &Kernel3d::Star.generate());
+    let (labels, nb_features) = label::<u8>(&data.mapv(|v| v > 0), &Kernel3d::Star.generate());
     assert_eq!(labels, star_result);
     assert_eq!(nb_features, 6);
 }
@@ -311,5 +311,5 @@ fn test_label_u8_panic() {
     unconnected_kernel[(1, 1, 1)] = true;
 
     // Try to label 1000 items, this would require 1000 labels and u8 only has 255, therefore we overflow and panic
-    label::<_, u8>(&Array3::from_elem((10, 10, 10), true), &unconnected_kernel);
+    label::<u8>(&Array3::from_elem((10, 10, 10), true), &unconnected_kernel);
 }


### PR DESCRIPTION
Mostly just Replaces `ArrayBase<S, D>` with `ArrayRef<A, D>` and removes the unnecessary type param `S` (and the corresponding trait guard).

Let me know what you think, I am not too familiar with the code base.

[Ndarray 0.17 Release Notes](https://github.com/rust-ndarray/ndarray/releases/tag/0.17.0)

Depends on: #28 